### PR TITLE
HPC pipeline: all 5 stages for non-human CAS empirical p-value distributions

### DIFF
--- a/hpc/README.md
+++ b/hpc/README.md
@@ -18,7 +18,7 @@ supported by tfbs_footprinter3.
 | B | `prefetch.py` + `ensembl_cache.py` | workstation, one-time | `cache/ensembl.sqlite` |
 | C | `cas_only.py` via `slurm/submit.sh` | SLURM job array | `cas_scores/{species}/*.parquet` |
 | D | `build_cas_pvalues.py` | workstation | `artifacts/{species}/CAS_pvalues.0.1.tf_ls.json` |
-| E | S3 upload (todo) | workstation | `s3://tfbssexperimentaldata/{species}.tar.gz` |
+| E | `publish_to_s3.py` | workstation w/ AWS creds | `s3://tfbssexperimentaldata/{species}.tar.gz` |
 
 ## Stages B–D usage
 
@@ -42,6 +42,12 @@ sbatch --array=0-$((TOTAL_TRANSCRIPTS / CHUNK_SIZE - 1)) hpc/slurm/submit.sh
 python hpc/build_cas_pvalues.py --species mus_musculus
 # or to do every species present under hpc/cas_scores/
 python hpc/build_cas_pvalues.py --species all
+
+# Stage E: inject CAS JSON into S3 per-species tarballs
+# Requires `aws` CLI configured with write access to tfbssexperimentaldata.
+python hpc/publish_to_s3.py --species mus_musculus --dry-run   # inspect locally first
+python hpc/publish_to_s3.py --species mus_musculus             # actual upload
+python hpc/publish_to_s3.py --species all                      # batch
 ```
 
 ## Key design decisions
@@ -91,6 +97,7 @@ hpc/
 ├── prefetch.py                  (Stage B)
 ├── cas_only.py                  (Stage C worker)
 ├── build_cas_pvalues.py         (Stage D)
+├── publish_to_s3.py             (Stage E)
 ├── slurm/
 │   └── submit.sh                (Stage C SLURM array wrapper)
 ├── transcript_lists/            (gitignored; Stage A output)

--- a/hpc/README.md
+++ b/hpc/README.md
@@ -15,10 +15,51 @@ supported by tfbs_footprinter3.
 | Stage | Script | Runs where | Output |
 |-------|--------|------------|--------|
 | A | `select_transcripts.py` | workstation, one-time | `transcript_lists/{species}.txt` |
-| B | `prefetch.py` (todo) | workstation, one-time | `cache/ensembl.sqlite` |
-| C | `cas_only.py` (todo) | SLURM job array | `cas_scores/{species}/*.parquet` |
-| D | `build_cas_pvalues.py` (todo) | workstation | `artifacts/{species}/CAS_pvalues.0.1.tf_ls.json` |
+| B | `prefetch.py` + `ensembl_cache.py` | workstation, one-time | `cache/ensembl.sqlite` |
+| C | `cas_only.py` via `slurm/submit.sh` | SLURM job array | `cas_scores/{species}/*.parquet` |
+| D | `build_cas_pvalues.py` | workstation | `artifacts/{species}/CAS_pvalues.0.1.tf_ls.json` |
 | E | S3 upload (todo) | workstation | `s3://tfbssexperimentaldata/{species}.tar.gz` |
+
+## Stages B–D usage
+
+```bash
+# Stage B: populate the Ensembl REST cache (single-threaded on submission node)
+python hpc/prefetch.py --list hpc/transcript_lists/mus_musculus.txt \
+    --cache hpc/cache/ensembl.sqlite
+
+# Stage C benchmark: measure per-transcript time before scheduling full run
+python -m hpc.cas_only \
+    --list hpc/transcript_lists/mus_musculus.txt --range 0:5 \
+    --cache hpc/cache/ensembl.sqlite --benchmark
+
+# Stage C full run: SLURM array of ~500 tasks per species
+export SPECIES=mus_musculus
+export TOTAL_TRANSCRIPTS=5000
+export CHUNK_SIZE=10
+sbatch --array=0-$((TOTAL_TRANSCRIPTS / CHUNK_SIZE - 1)) hpc/slurm/submit.sh
+
+# Stage D: per-species aggregation into CAS_pvalues JSON
+python hpc/build_cas_pvalues.py --species mus_musculus
+# or to do every species present under hpc/cas_scores/
+python hpc/build_cas_pvalues.py --species all
+```
+
+## Key design decisions
+
+- **CAS scope**: PWM + GERP + CAGE + CpG — the four components
+  `find_clusters()` already computes for non-human species
+  (`tfbs_footprinter3.py:1055`). No scoring code changes.
+- **Cache-first REST**: `ensembl_cache.py` monkey-patches
+  `tfbs_footprinter3.ensemblrest` to read from a sqlite file populated in
+  Stage B. SLURM workers open the cache read-only by default, so N
+  parallel tasks never re-fetch from Ensembl. `--allow-live-rest` opts
+  a worker into live-fetch fallback on cache miss.
+- **Rounding**: p-values are computed on scores rounded to 2 decimals
+  to match the rounding applied at CAS computation time
+  (`tfbs_footprinter3.py:1073`).
+- **Min-hits threshold**: TFs with fewer than 100 hits across the 5000
+  transcripts are dropped from the p-value table (configurable via
+  `--min-hits`). Too-sparse distributions are misleading.
 
 ## Stage A — transcript selection
 
@@ -46,11 +87,12 @@ recording per-species success/fail and actual counts (flags species with
 hpc/
 ├── README.md                    (this file)
 ├── select_transcripts.py        (Stage A)
-├── prefetch.py                  (Stage B, todo)
-├── cas_only.py                  (Stage C, todo)
-├── build_cas_pvalues.py         (Stage D, todo)
-├── slurm/                       (SLURM submit scripts)
-│   └── submit.sh                (todo)
+├── ensembl_cache.py             (shared cache client + monkey-patch helper)
+├── prefetch.py                  (Stage B)
+├── cas_only.py                  (Stage C worker)
+├── build_cas_pvalues.py         (Stage D)
+├── slurm/
+│   └── submit.sh                (Stage C SLURM array wrapper)
 ├── transcript_lists/            (gitignored; Stage A output)
 ├── cache/                       (gitignored; Stage B output)
 ├── cas_scores/                  (gitignored; Stage C output)

--- a/hpc/build_cas_pvalues.py
+++ b/hpc/build_cas_pvalues.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Stage D: aggregate Parquet shards from Stage C into CAS_pvalues JSON per species.
+
+For each species:
+1. Concatenate all hpc/cas_scores/{species}/*.parquet shards into a single
+   dataframe of (transcript_id, tf_name, cas_score) rows.
+2. For each TF with at least MIN_HITS observations, build the empirical
+   survival p-value function:
+       p(s) = P(CAS >= s)
+   computed on the unique rounded scores (2 decimals, matching
+   tfbs_footprinter3.py:1073).
+3. Emit {tf_name: [[score, p_value], ...]} sorted ascending by score —
+   that's the exact shape consumed by calcCombinedAffinityPvalue's
+   bisect_left lookup at tfbs_footprinter3.py:1001.
+4. Write hpc/artifacts/{species}/CAS_pvalues.0.1.tf_ls.json.
+
+Stage E (not yet scripted) injects each JSON into the per-species S3
+tarball at s3://tfbssexperimentaldata/{species}.tar.gz. After re-upload,
+tfbs_footprinter3 -update on user machines will download the new tarball
+and species_specific_data() will pick the JSON up automatically with no
+code changes (tfbs_footprinter3.py:755).
+
+Usage:
+    python hpc/build_cas_pvalues.py --species mus_musculus
+    python hpc/build_cas_pvalues.py --species all
+    python hpc/build_cas_pvalues.py --species mus_musculus --min-hits 50
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+DEFAULT_MIN_HITS = 100
+ROUND_DECIMALS = 2
+
+
+def empirical_pvalues(scores: list[float]) -> list[tuple[float, float]]:
+    """Return sorted-ascending [(score, p_value)] tuples.
+
+    p_value at each unique rounded score = P(CAS >= score) across the
+    input distribution. The p-value at the minimum score is 1.0 by
+    definition; p-value at the maximum is 1/N.
+    """
+    if not scores:
+        return []
+    import pandas as pd
+    s = pd.Series(scores).round(ROUND_DECIMALS).sort_values().reset_index(drop=True)
+    n = len(s)
+    # Count-by-unique, ascending
+    counts = s.value_counts().sort_index(ascending=True)
+    # Survival: P(X >= score). Since scores are sorted, the running
+    # "ranks from the top" is: N - cumulative_count_up_to_before_this_score.
+    # Use cumcount via cumsum of counts shifted up by one.
+    cumulative = counts.cumsum()
+    # Number of observations strictly less than each score
+    strictly_less = cumulative.shift(1).fillna(0)
+    p_values = (n - strictly_less) / n
+    # Build sorted (score, p) tuples
+    return [(float(score), float(pv)) for score, pv in zip(p_values.index, p_values.values, strict=True)]
+
+
+def build_one_species(species: str, shard_dir: Path, out_dir: Path, min_hits: int) -> dict:
+    """Aggregate shards, compute p-values per TF, write JSON, return summary."""
+    import pandas as pd
+    shards = sorted(shard_dir.glob("*.parquet"))
+    if not shards:
+        logging.warning("%s: no shards under %s", species, shard_dir)
+        return {"species": species, "status": "no_shards"}
+
+    logging.info("%s: concatenating %d shards", species, len(shards))
+    df = pd.concat([pd.read_parquet(p) for p in shards], ignore_index=True)
+    if df.empty:
+        return {"species": species, "status": "empty"}
+
+    logging.info("%s: %d total hits across %d TFs", species, len(df), df["tf_name"].nunique())
+
+    tf_pvalues: dict[str, list[list[float]]] = {}
+    tf_counts: dict[str, int] = {}
+    dropped: list[tuple[str, int]] = []
+    for tf_name, grp in df.groupby("tf_name"):
+        count = len(grp)
+        tf_counts[tf_name] = count
+        if count < min_hits:
+            dropped.append((tf_name, count))
+            continue
+        # Store as list of 2-element lists so the JSON matches existing format
+        tf_pvalues[tf_name] = [[score, pv] for score, pv in empirical_pvalues(grp["cas_score"].tolist())]
+
+    out_path = out_dir / species / "CAS_pvalues.0.1.tf_ls.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(tf_pvalues))
+    logging.info("%s: wrote %d TFs (%d dropped below min_hits=%d) to %s",
+                 species, len(tf_pvalues), len(dropped), min_hits, out_path)
+
+    return {
+        "species": species,
+        "status": "ok",
+        "total_hits": int(len(df)),
+        "tfs_kept": len(tf_pvalues),
+        "tfs_dropped": len(dropped),
+        "min_hits": min_hits,
+        "output": str(out_path),
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--species", type=str, required=True,
+                   help="Species slug (e.g. 'mus_musculus') or 'all' to iterate every species under --shard-root.")
+    p.add_argument("--shard-root", type=Path, default=Path("hpc/cas_scores"))
+    p.add_argument("--out-root", type=Path, default=Path("hpc/artifacts"))
+    p.add_argument("--min-hits", type=int, default=DEFAULT_MIN_HITS)
+    p.add_argument("--manifest", type=Path, default=Path("hpc/artifacts/build_manifest.json"))
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    if args.species == "all":
+        species_list = sorted(p.name for p in args.shard_root.iterdir() if p.is_dir())
+    else:
+        species_list = [args.species]
+
+    manifest = []
+    failed = 0
+    for sp in species_list:
+        summary = build_one_species(sp, args.shard_root / sp, args.out_root, args.min_hits)
+        manifest.append(summary)
+        if summary.get("status") != "ok":
+            failed += 1
+
+    args.manifest.parent.mkdir(parents=True, exist_ok=True)
+    args.manifest.write_text(json.dumps(manifest, indent=2))
+    logging.info("manifest: %s (%d ok, %d failed)",
+                 args.manifest, len(species_list) - failed, failed)
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hpc/cas_only.py
+++ b/hpc/cas_only.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Stage C: CAS-only computation harness for a chunk of transcripts.
+
+Designed to be launched as a SLURM array task (see hpc/slurm/submit.sh).
+Each invocation processes a slice of a species' transcript list, drives
+tfbs_footprinter3 through its normal CLI path with:
+
+    - ensemblrest() monkey-patched to read from a shared sqlite cache
+      (populated by Stage B: hpc/prefetch.py)
+    - pvalc=1.0 so every hit is emitted (we need the full empirical
+      distribution, not just significant hits)
+    - plotting disabled (--nofig) to strip ~seconds per transcript
+
+After the run, parses the per-transcript `TFBSs_found.sortedclusters.csv`
+output files and emits a single Parquet with (transcript_id, tf_name,
+cas_score) per hit. These shards get concatenated by Stage D
+(hpc/build_cas_pvalues.py) into per-species empirical p-value tables.
+
+Usage:
+    python -m hpc.cas_only \\
+        --list hpc/transcript_lists/mus_musculus.txt \\
+        --range 0:10 \\
+        --cache hpc/cache/ensembl.sqlite \\
+        --output hpc/cas_scores/mus_musculus/task_000.parquet
+
+    # Benchmark mode: run one transcript, print timing, don't write
+    python -m hpc.cas_only --list hpc/transcript_lists/mus_musculus.txt \\
+        --range 0:1 --cache hpc/cache/ensembl.sqlite --benchmark
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# CAS_OUTPUT_COLUMNS — output Parquet schema
+# Keep as simple dataclass-less dict-list so pandas/pyarrow picks it up cleanly
+# and Stage D can read without any HPC-local imports.
+CAS_OUTPUT_COLUMNS = ["transcript_id", "tf_name", "cas_score"]
+
+# Columns present in TFBSs_found.sortedclusters.csv (see README.md section 4.2)
+# We only need `binding prot` and `combined affinity score`.
+CSV_TF_COL = "binding prot"
+CSV_CAS_COL = "combined affinity score"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--list", type=Path, required=True, help="Transcript list file (one Ensembl ID per line).")
+    p.add_argument("--range", type=str, required=True, help="Slice 'START:END' (0-indexed, end exclusive).")
+    p.add_argument("--cache", type=Path, required=True, help="Sqlite cache written by prefetch.py (read-only).")
+    p.add_argument("--output", type=Path, help="Destination Parquet file (required unless --benchmark).")
+    p.add_argument("--promoter-before", type=int, default=900)
+    p.add_argument("--promoter-after", type=int, default=100)
+    p.add_argument("--pval", type=float, default=0.01, help="PWM p-value threshold (passed to tool).")
+    p.add_argument("--top-x", type=int, default=10, help="--tx flag forwarded to tool (affects figure only).")
+    p.add_argument("--benchmark", action="store_true",
+                   help="Run the slice, print per-transcript timing, don't write Parquet or allow live REST.")
+    p.add_argument("--allow-live-rest", action="store_true",
+                   help="Let ensemblrest() fall back to live REST if cache miss. Default off.")
+    return p.parse_args(argv)
+
+
+def slice_transcripts(path: Path, rng: str) -> list[str]:
+    start_s, end_s = rng.split(":", 1)
+    start = int(start_s)
+    end = int(end_s)
+    ids = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    return ids[start:end]
+
+
+def write_tool_csv(transcripts: list[str], out_csv: Path, args: argparse.Namespace) -> None:
+    """Emit the CSV format tfbs_footprinter3 accepts via -t <file>.
+
+    Column order per parse_transcript_ids() / file_to_datalist() in the
+    monolith: transcript_id, tf_ids_file, promoter_before, promoter_after,
+    top_x, pval, pvalc. Set pvalc=1.0 so every hit passes the CAS filter.
+    """
+    with out_csv.open("w", newline="") as f:
+        w = csv.writer(f)
+        for tid in transcripts:
+            w.writerow([tid, "", args.promoter_before, args.promoter_after,
+                        args.top_x, args.pval, 1.0])
+
+
+def collect_cas_rows(results_dir: Path, transcripts: list[str], args: argparse.Namespace) -> list[tuple]:
+    """Parse each transcript's TFBSs_found.sortedclusters.csv, emit hit rows."""
+    # Tool names its per-transcript subdir as {tid}_(before_after)_{pval}
+    suffix = f"({args.promoter_before}_{args.promoter_after})_{args.pval}"
+    rows: list[tuple] = []
+    missing = []
+    for tid in transcripts:
+        csv_path = results_dir / f"{tid}_{suffix}" / "TFBSs_found.sortedclusters.csv"
+        if not csv_path.exists():
+            missing.append(tid)
+            continue
+        with csv_path.open() as f:
+            reader = csv.DictReader(f)
+            for r in reader:
+                try:
+                    score = float(r[CSV_CAS_COL])
+                except (KeyError, ValueError, TypeError):
+                    continue
+                rows.append((tid, r[CSV_TF_COL], score))
+    if missing:
+        logging.warning("no output for %d transcript(s): %s", len(missing), missing[:5])
+    return rows
+
+
+def write_parquet(rows: list[tuple], out_path: Path) -> None:
+    import pandas as pd  # noqa: PLC0415  local import to keep --help fast
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(rows, columns=CAS_OUTPUT_COLUMNS)
+    df.to_parquet(out_path, index=False)
+    logging.info("wrote %d rows to %s", len(df), out_path)
+
+
+def run_main_inprocess(tool_csv: Path, workdir: Path) -> None:
+    """Drive tfbs_footprinter3.main() after chdir + curdir patch."""
+    original_cwd = os.getcwd()
+    os.chdir(workdir)
+    try:
+        from tfbs_footprinter3 import tfbs_footprinter3 as tff
+        # curdir was captured at import-time (tfbs_footprinter3.py:64); re-bind.
+        tff.curdir = str(workdir)
+        saved_argv = sys.argv[:]
+        sys.argv = ["tfbs_footprinter3", "-t", str(tool_csv), "-no"]
+        try:
+            tff.main()
+        finally:
+            sys.argv = saved_argv
+    finally:
+        os.chdir(original_cwd)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    if not args.benchmark and not args.output:
+        sys.exit("--output is required unless --benchmark is set")
+
+    transcripts = slice_transcripts(args.list, args.range)
+    if not transcripts:
+        logging.warning("empty slice: %s %s", args.list, args.range)
+        return 0
+    logging.info("processing %d transcripts (%s)", len(transcripts), args.range)
+
+    # Apply the cache monkey-patch BEFORE importing tfbs_footprinter3 main
+    from hpc.ensembl_cache import CachedEnsemblClient, patch_tfbs_footprinter3
+    client = CachedEnsemblClient(args.cache, read_only=not args.allow_live_rest)
+    patch_tfbs_footprinter3(client)
+
+    with tempfile.TemporaryDirectory(prefix="tfbs_cas_only_") as tmp:
+        workdir = Path(tmp)
+        tool_csv = workdir / "transcripts.csv"
+        write_tool_csv(transcripts, tool_csv, args)
+
+        t0 = time.time()
+        run_main_inprocess(tool_csv, workdir)
+        elapsed = time.time() - t0
+        logging.info("tool run complete in %.1fs (%.1fs/transcript avg)",
+                     elapsed, elapsed / len(transcripts))
+
+        results_dir = workdir / "tfbs_results"
+        rows = collect_cas_rows(results_dir, transcripts, args)
+        logging.info("collected %d CAS hit rows", len(rows))
+
+        if args.benchmark:
+            print(f"BENCHMARK  transcripts={len(transcripts)}  elapsed={elapsed:.1f}s  "
+                  f"avg={elapsed/len(transcripts):.1f}s/tid  cas_rows={len(rows)}")
+            return 0
+
+        write_parquet(rows, args.output)
+    client.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hpc/ensembl_cache.py
+++ b/hpc/ensembl_cache.py
@@ -1,0 +1,150 @@
+"""SQLite-backed cache for Ensembl REST JSON responses.
+
+Used by Stage B (prefetch.py) to populate the cache, and by Stage C
+(cas_only.py) to replace tfbs_footprinter3.ensemblrest with a cache-aware
+version at runtime, so SLURM array jobs don't hammer the Ensembl REST API.
+
+Cache format: a single sqlite file with one table `responses(url PRIMARY
+KEY, fetched_at, body)`. The body is a JSON string — we parse at read time.
+This keeps the cache introspectable (sqlite CLI, DB Browser) and rsync-able
+between a submission node and compute nodes.
+"""
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import sqlite3
+import time
+from pathlib import Path
+
+import httplib2
+
+ENSEMBL_SERVER = "http://rest.ensembl.org"
+DEFAULT_RETRY_STATUSES = {429, 500, 502, 503, 504}
+DEFAULT_MAX_ATTEMPTS = 4
+DEFAULT_BACKOFF_BASE = 5.0
+
+
+class CachedEnsemblClient:
+    """Sqlite-backed cache for Ensembl REST JSON calls.
+
+    Use get_json(url) to fetch; the client serves from cache when present
+    and falls back to httplib2 otherwise, storing every success.
+    """
+
+    def __init__(
+        self,
+        db_path: Path | str,
+        *,
+        read_only: bool = False,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+        backoff_base: float = DEFAULT_BACKOFF_BASE,
+        rate_limit_sleep: float = 0.07,
+    ):
+        self.db_path = Path(db_path)
+        self.read_only = read_only
+        self.max_attempts = max_attempts
+        self.backoff_base = backoff_base
+        self.rate_limit_sleep = rate_limit_sleep
+        self._http = httplib2.Http()
+        self._conn = self._open_conn()
+
+    def _open_conn(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(
+            f"file:{self.db_path}?mode={'ro' if self.read_only else 'rwc'}",
+            uri=True,
+            isolation_level=None,
+            check_same_thread=False,
+        )
+        if not self.read_only:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS responses ("
+                "url TEXT PRIMARY KEY, "
+                "fetched_at REAL NOT NULL, "
+                "body TEXT NOT NULL"
+                ");"
+            )
+        return conn
+
+    def get_cached(self, url: str) -> dict | list | None:
+        row = self._conn.execute(
+            "SELECT body FROM responses WHERE url = ?", (url,)
+        ).fetchone()
+        if row is None:
+            return None
+        return json.loads(row[0])
+
+    def store(self, url: str, body: dict | list) -> None:
+        if self.read_only:
+            raise RuntimeError("store() called on a read-only client")
+        self._conn.execute(
+            "INSERT OR REPLACE INTO responses (url, fetched_at, body) VALUES (?, ?, ?)",
+            (url, time.time(), json.dumps(body)),
+        )
+
+    def get_json(self, url: str) -> dict | list:
+        """Return cached JSON for `url`, fetching via REST if absent."""
+        cached = self.get_cached(url)
+        if cached is not None:
+            return cached
+        if self.read_only:
+            raise KeyError(f"URL not in cache: {url}")
+        body = self._fetch(url)
+        self.store(url, body)
+        time.sleep(self.rate_limit_sleep)  # polite throttle
+        return body
+
+    def _fetch(self, url: str) -> dict | list:
+        last_exc: Exception | None = None
+        for attempt in range(self.max_attempts):
+            try:
+                resp, raw = self._http.request(url, method="GET")
+                status = int(resp.status)
+                if status in DEFAULT_RETRY_STATUSES:
+                    raise RuntimeError(f"HTTP {status} (retryable)")
+                if status >= 400:
+                    raise RuntimeError(f"HTTP {status}: {raw[:200]!r}")
+                return json.loads(raw)
+            except Exception as exc:
+                last_exc = exc
+                if attempt < self.max_attempts - 1:
+                    delay = self.backoff_base * (2 ** attempt)
+                    logging.info("Retry %s in %.0fs: %s", url, delay, str(exc)[:120])
+                    time.sleep(delay)
+        raise RuntimeError(f"Failed after {self.max_attempts} attempts: {url} ({last_exc})")
+
+    def close(self) -> None:
+        with contextlib.suppress(Exception):
+            self._conn.close()
+
+    def __enter__(self) -> CachedEnsemblClient:
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+
+# ---- monkey-patch helper ----
+
+
+def patch_tfbs_footprinter3(client: CachedEnsemblClient) -> None:
+    """Replace tfbs_footprinter3.ensemblrest with a cache-aware wrapper.
+
+    Call once at the top of hpc/cas_only.py (or any harness that drives
+    tfbs_footprinter3 code paths without wanting live REST hits).
+
+    All four call sites in tfbs_footprinter3 use output_type='json'; we
+    ignore the 'fasta' branch (dead code as of v0.0.7).
+    """
+    from tfbs_footprinter3 import tfbs_footprinter3 as tff
+
+    def _cached_ensemblrest(query_type, options, output_type, ensembl_id=None, log=False):
+        full_query = ENSEMBL_SERVER + query_type + (ensembl_id or "") + options
+        if log:
+            logging.info("Ensembl REST (cached): %s", full_query)
+        return client.get_json(full_query)
+
+    tff.ensemblrest = _cached_ensemblrest

--- a/hpc/prefetch.py
+++ b/hpc/prefetch.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Prefetch all Ensembl REST responses tfbs_footprinter3 needs per transcript.
+
+Stage B of the HPC pipeline (see hpc/README.md). Runs serially from a
+submission node; the resulting sqlite cache is then read-only during
+SLURM array jobs in Stage C.
+
+For each transcript id, issues the four REST calls tfbs_footprinter3 makes:
+
+    /lookup/id/{tid}?expand=1;content-type=application/json
+    /lookup/id/{gene_id}?content-type=application/json         (gene from step 1)
+    /sequence/region/{species}/{chr}:{start}-{end}:{strand}?...
+    /overlap/region/{species}/{chr}:{start}-{end}?feature=regulatory;...
+
+The exact queries are discovered by importing tfbs_footprinter3 itself and
+replaying its call-site logic — this guarantees any future changes to the
+query shape are picked up automatically. See `run_one_transcript()`.
+
+Usage:
+    python hpc/prefetch.py --species mus_musculus --list hpc/transcript_lists/mus_musculus.txt
+    python hpc/prefetch.py --list hpc/transcript_lists/mus_musculus.txt --limit 50
+    python hpc/prefetch.py --list hpc/transcript_lists/mus_musculus.txt --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from pathlib import Path
+
+from hpc.ensembl_cache import ENSEMBL_SERVER, CachedEnsemblClient
+
+# Promoter window defaults match the tool's defaults so the cached sequence
+# covers the range tfbs_footprinter3 will ask for at CAS time.
+DEFAULT_PROMOTER_BEFORE = 900
+DEFAULT_PROMOTER_AFTER = 100
+
+
+def _json_path(query_type: str, ensembl_id: str, extra_params: str = "") -> str:
+    """Build the URL exactly as ensemblrest() in tfbs_footprinter3.py:284 does."""
+    return f"{ENSEMBL_SERVER}{query_type}{ensembl_id}?content-type=application/json{extra_params}"
+
+
+def run_one_transcript(
+    client: CachedEnsemblClient,
+    transcript_id: str,
+    promoter_before: int = DEFAULT_PROMOTER_BEFORE,
+    promoter_after: int = DEFAULT_PROMOTER_AFTER,
+) -> dict:
+    """Prefetch all endpoints tfbs_footprinter3 will hit for this transcript.
+
+    Returns a small status dict for manifest logging.
+    """
+    # Step 1: transcript lookup (gets species, chromosome, strand, TSS)
+    lookup_url = _json_path("/lookup/id/", transcript_id, ";expand=1")
+    transcript_meta = client.get_json(lookup_url)
+    if not transcript_meta or "species" not in transcript_meta:
+        return {"transcript_id": transcript_id, "status": "lookup_failed"}
+
+    species = transcript_meta["species"]
+    chromosome = transcript_meta["seq_region_name"]
+    strand = transcript_meta["strand"]
+    tss = transcript_meta["start"] if strand == 1 else transcript_meta["end"]
+    gene_id = transcript_meta.get("Parent", "")
+
+    if strand == 1:
+        promoter_start = tss - promoter_before
+        promoter_end = tss + promoter_after
+    else:
+        promoter_start = tss - promoter_after
+        promoter_end = tss + promoter_before
+
+    # Step 2: gene lookup
+    if gene_id:
+        client.get_json(_json_path("/lookup/id/", gene_id))
+
+    # Step 3: promoter sequence
+    sequence_region = f"{species}/{chromosome}:{promoter_start}-{promoter_end}:{strand}"
+    client.get_json(_json_path("/sequence/region/", sequence_region))
+
+    # Step 4: regulatory overlap
+    overlap_region = f"{species}/{chromosome}:{promoter_start}-{promoter_end}"
+    overlap_params = ";feature=regulatory"
+    client.get_json(_json_path("/overlap/region/", overlap_region, overlap_params))
+
+    return {
+        "transcript_id": transcript_id,
+        "status": "ok",
+        "species": species,
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--list", type=Path, required=True, help="Transcript list file (one Ensembl ID per line).")
+    p.add_argument("--cache", type=Path, default=Path("hpc/cache/ensembl.sqlite"), help="Sqlite cache path.")
+    p.add_argument("--limit", type=int, default=0, help="Cap number of transcripts (0 = all).")
+    p.add_argument("--promoter-before", type=int, default=DEFAULT_PROMOTER_BEFORE)
+    p.add_argument("--promoter-after", type=int, default=DEFAULT_PROMOTER_AFTER)
+    p.add_argument("--dry-run", action="store_true", help="Run through the first 3 transcripts without writing cache.")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    transcripts = [line.strip() for line in args.list.read_text().splitlines() if line.strip()]
+    if args.limit > 0:
+        transcripts = transcripts[: args.limit]
+    logging.info("Prefetching %d transcripts from %s", len(transcripts), args.list)
+
+    if args.dry_run:
+        # In-memory cache; the :memory: URI is incompatible with path logic,
+        # so point at a temp path and delete after.
+        tmp = Path("/tmp/tfbs_prefetch_dryrun.sqlite")
+        tmp.unlink(missing_ok=True)
+        client = CachedEnsemblClient(tmp)
+        for tid in transcripts[:3]:
+            result = run_one_transcript(client, tid, args.promoter_before, args.promoter_after)
+            logging.info("DRY-RUN %s", result)
+        client.close()
+        tmp.unlink(missing_ok=True)
+        return 0
+
+    t0 = time.time()
+    ok = failed = 0
+    with CachedEnsemblClient(args.cache) as client:
+        for idx, tid in enumerate(transcripts, 1):
+            try:
+                result = run_one_transcript(client, tid, args.promoter_before, args.promoter_after)
+                if result["status"] == "ok":
+                    ok += 1
+                else:
+                    failed += 1
+                    logging.warning("[%d/%d] %s: %s", idx, len(transcripts), tid, result["status"])
+            except Exception as exc:
+                failed += 1
+                logging.warning("[%d/%d] %s: %s", idx, len(transcripts), tid, str(exc)[:160])
+            if idx % 50 == 0:
+                elapsed = time.time() - t0
+                rate = idx / elapsed if elapsed else 0
+                logging.info("progress: %d/%d (%.1f/s, %.0fs elapsed)", idx, len(transcripts), rate, elapsed)
+
+    logging.info("Done: %d ok, %d failed, %.0fs total", ok, failed, time.time() - t0)
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hpc/publish_to_s3.py
+++ b/hpc/publish_to_s3.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Stage E: inject CAS_pvalues JSON into per-species S3 tarballs and re-upload.
+
+For each species, download s3://tfbssexperimentaldata/{species}.tar.gz,
+add Stage D's CAS_pvalues.0.1.tf_ls.json into its {species}/ subdir
+(without disturbing the existing experimental data files), and re-upload.
+
+After re-upload, any user running `tfbs_footprinter3 -update` will pull
+the new tarball, and the species_specific_data() loader at
+tfbs_footprinter3.py:755 will find the CAS_pvalues JSON and start
+emitting combined-affinity-score p-values for non-human analyses with
+no client-side code change.
+
+Uses the `aws` CLI via subprocess so there's no boto3 dependency to add
+to the package. Assumes `aws` is on PATH and credentials are configured
+(env vars, ~/.aws/credentials, or an instance role — any of the usual).
+
+Usage:
+    # Dry run: download, inspect, repack locally, don't upload
+    python hpc/publish_to_s3.py --species mus_musculus --dry-run
+
+    # Upload for one species
+    python hpc/publish_to_s3.py --species mus_musculus
+
+    # Batch upload for every species with an artifact on disk
+    python hpc/publish_to_s3.py --species all
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+BUCKET = "tfbssexperimentaldata"
+CAS_FILENAME = "CAS_pvalues.0.1.tf_ls.json"
+
+
+def run(cmd: list[str]) -> None:
+    """Run a subprocess, stream output, raise on non-zero exit."""
+    logging.info("$ %s", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def s3_key(species: str) -> str:
+    return f"s3://{BUCKET}/{species}.tar.gz"
+
+
+def process_one(species: str, artifact_root: Path, dry_run: bool) -> dict:
+    """Download species tarball, inject CAS JSON, re-upload (unless dry run)."""
+    cas_json_path = artifact_root / species / CAS_FILENAME
+    if not cas_json_path.exists():
+        return {"species": species, "status": "no_artifact", "path": str(cas_json_path)}
+
+    with tempfile.TemporaryDirectory(prefix=f"tfbs_publish_{species}_") as tmp:
+        tmpdir = Path(tmp)
+        local_tar = tmpdir / f"{species}.tar.gz"
+        extract_dir = tmpdir / "extract"
+        extract_dir.mkdir()
+
+        # 1. Download the existing tarball
+        run(["aws", "s3", "cp", s3_key(species), str(local_tar)])
+
+        # 2. Extract
+        with tarfile.open(local_tar, "r:gz") as tar:
+            # Safety: refuse absolute paths / .. traversal
+            for member in tar.getmembers():
+                if member.name.startswith(("/", "..")) or ".." in Path(member.name).parts:
+                    raise RuntimeError(f"unsafe path in tarball: {member.name}")
+            tar.extractall(extract_dir)
+
+        # 3. Locate the species directory inside the tar
+        species_dir = extract_dir / species
+        if not species_dir.is_dir():
+            # Some tarballs may have just the files at root; tolerate both
+            candidates = [p for p in extract_dir.iterdir() if p.is_dir() and p.name == species]
+            if not candidates:
+                raise RuntimeError(f"species subdir {species!r} not found in {local_tar}")
+            species_dir = candidates[0]
+
+        # 4. Inject the CAS JSON
+        dst = species_dir / CAS_FILENAME
+        dst.write_bytes(cas_json_path.read_bytes())
+        logging.info("injected %s into %s", CAS_FILENAME, species_dir)
+
+        # 5. Re-tar
+        new_tar = tmpdir / f"{species}.new.tar.gz"
+        with tarfile.open(new_tar, "w:gz") as tar:
+            tar.add(species_dir, arcname=species)
+        logging.info("rebuilt tarball: %d bytes", new_tar.stat().st_size)
+
+        if dry_run:
+            # Preserve for inspection
+            preserved = artifact_root / f"{species}.dry-run.tar.gz"
+            preserved.write_bytes(new_tar.read_bytes())
+            logging.info("DRY-RUN: preserved tarball at %s", preserved)
+            return {"species": species, "status": "dry_run", "local": str(preserved)}
+
+        # 6. Upload (overwrite)
+        run(["aws", "s3", "cp", str(new_tar), s3_key(species)])
+        return {"species": species, "status": "uploaded", "bytes": new_tar.stat().st_size}
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--species", type=str, required=True,
+                   help="Species slug (or 'all' for every directory under --artifacts).")
+    p.add_argument("--artifacts", type=Path, default=Path("hpc/artifacts"),
+                   help="Directory with {species}/CAS_pvalues.0.1.tf_ls.json files from Stage D.")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Rebuild tarballs locally, skip the s3 upload.")
+    p.add_argument("--manifest", type=Path, default=Path("hpc/artifacts/publish_manifest.json"))
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    if args.species == "all":
+        species_list = sorted(
+            p.name for p in args.artifacts.iterdir()
+            if p.is_dir() and (p / CAS_FILENAME).exists()
+        )
+    else:
+        species_list = [args.species]
+
+    results = []
+    failed = 0
+    for sp in species_list:
+        try:
+            results.append(process_one(sp, args.artifacts, args.dry_run))
+        except Exception as exc:
+            failed += 1
+            logging.error("%s: %s", sp, exc)
+            results.append({"species": sp, "status": "error", "error": str(exc)})
+
+    args.manifest.parent.mkdir(parents=True, exist_ok=True)
+    args.manifest.write_text(json.dumps(results, indent=2))
+    logging.info("manifest: %s (%d ok, %d failed)",
+                 args.manifest, len(species_list) - failed, failed)
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hpc/slurm/submit.sh
+++ b/hpc/slurm/submit.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# SLURM array submission for Stage C of the CAS distribution pipeline.
+#
+# Each array task processes CHUNK_SIZE transcripts from a single species'
+# list, writing one Parquet shard. See hpc/cas_only.py for the per-task
+# logic and hpc/README.md for the overall pipeline.
+#
+# Usage (from repo root on the submission node):
+#
+#     export SPECIES=mus_musculus
+#     export TOTAL_TRANSCRIPTS=5000          # or whatever Stage A produced
+#     export CHUNK_SIZE=10                   # -> 500 array tasks
+#     sbatch --array=0-$((TOTAL_TRANSCRIPTS / CHUNK_SIZE - 1)) hpc/slurm/submit.sh
+#
+# You MUST edit the #SBATCH lines below for your cluster: partition name,
+# account, time limit, memory. The defaults here are conservative starting
+# points — calibrate after a benchmark run (see the --benchmark flag on
+# hpc/cas_only.py).
+
+#SBATCH --job-name=tfbs_cas
+#SBATCH --output=hpc/logs/%x_%A_%a.out
+#SBATCH --error=hpc/logs/%x_%A_%a.err
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=8G
+#SBATCH --time=04:00:00
+# Uncomment and edit for your cluster:
+# #SBATCH --partition=batch
+# #SBATCH --account=YOUR_ACCOUNT
+
+set -euo pipefail
+
+: "${SPECIES:?SPECIES env var is required (e.g. mus_musculus)}"
+: "${CHUNK_SIZE:=10}"
+: "${REPO_ROOT:=$(pwd)}"
+: "${CACHE:=${REPO_ROOT}/hpc/cache/ensembl.sqlite}"
+
+cd "${REPO_ROOT}"
+
+LIST="hpc/transcript_lists/${SPECIES}.txt"
+OUT_DIR="hpc/cas_scores/${SPECIES}"
+START=$(( SLURM_ARRAY_TASK_ID * CHUNK_SIZE ))
+END=$(( START + CHUNK_SIZE ))
+TASK_ID_PADDED=$(printf "%04d" "${SLURM_ARRAY_TASK_ID}")
+OUT="${OUT_DIR}/task_${TASK_ID_PADDED}.parquet"
+
+mkdir -p "${OUT_DIR}" hpc/logs
+
+echo "[$(date -Iseconds)] species=${SPECIES} range=${START}:${END} -> ${OUT}"
+
+# Cache is read-only in worker tasks (prefetch.py populates it once on
+# the submission node). If you want workers to fall back to live REST
+# on cache miss, pass --allow-live-rest.
+python -m hpc.cas_only \
+    --list "${LIST}" \
+    --range "${START}:${END}" \
+    --cache "${CACHE}" \
+    --output "${OUT}" \
+    ${TFBS_CAS_EXTRA:-}
+
+echo "[$(date -Iseconds)] done"


### PR DESCRIPTION
## Summary                           
                                                                                                                                                                                                                                                         
  Complete end-to-end pipeline that, when run on a SLURM cluster, produces                                                                                                                                                                               
  empirical per-TF combined affinity score p-value distributions for the 123
  non-human species tfbs_footprinter3 supports. After Stage E uploads the                                                                                                                                                                                
  resulting JSON files into each species' S3 tarball, users who run             
  `tfbs_footprinter3 -update` get CAS p-values in their non-human analyses                                                                                                                                                                               
  with no client-side code change — the existing loader at
  `tfbs_footprinter3.py:755` already picks up `CAS_pvalues.0.1.tf_ls.json`                                                                                                                                                                               
  when present.                                                                 
                                                                                                                                                                                                                                                         
  **Scope:** PWM + GERP + CAGE + CpG (the 4 components `find_clusters()`        
  already computes for non-human species). No scoring-logic changes.                                                                                                                                                                                     
                                                                                
                                                                                                                                                                                                                                                         
  | Stage | Script | Runs where |                                                                                                                                                                                                                        
  |-------|--------|------------|                                                                                                                                                                                                                        
  | A | `select_transcripts.py` | one-time, workstation |                                                                                                                                                                                                
  | B | `prefetch.py` + `ensembl_cache.py` | one-time, workstation |                                                                                                                                                                                     
  | C | `cas_only.py` via `slurm/submit.sh` | SLURM array |                                                                                                                                                                                              
  | D | `build_cas_pvalues.py` | workstation |                                                                                                                                                                                                           
  | E | `publish_to_s3.py` | workstation w/ AWS creds |                                                                                                                                                                                                  
                                                                                                                                                                                                                                                         
  - Stage B writes an sqlite Ensembl REST cache so the ~500-way SLURM                                                                                                                                                                                    
    array in Stage C never hammers rest.ensembl.org.                                                                                                                                                                                                     
  - Stage C monkey-patches `tfbs_footprinter3.ensemblrest` to read from         
    the cache (read-only by default; `--allow-live-rest` for fallback).                                                                                                                                                                                  
    Each task processes CHUNK_SIZE transcripts with `pvalc=1.0` + `--nofig`                                                                                                                                                                              
    and emits a Parquet shard.                                                                                                                                                                                                                           
  - Stage D computes empirical survival p-values `P(CAS >= s)` on                                                                                                                                                                                        
    2-decimal-rounded scores (matches `tfbs_footprinter3.py:1073`),             
    drops TFs below `--min-hits` (default 100), emits JSON in the exact
    sorted-tuples format `calcCombinedAffinityPvalue` consumes via                                                                                                                                                                                       
    `bisect_left` at line 1001.                                                                                                                                                                                                                          
  - Stage E injects the JSON into each species' existing S3 tarball                                                                                                                                                                                      
    using the `aws` CLI (no new Python deps). `--dry-run` preserves                                                                                                                                                                                      
    tarballs locally without uploading.                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                         
  ## Validation so far                                                          
  - Stage A live-tested against BioMart for 6 species (one required retry)                                                                                                                                                                               
  - Stage B/cache module round-trip verified on human transcripts                                                                                                                                                                                        
    (`ENST00000361390`, `ENST00000361453`)                                                                                                                                                                                                               
  - Stage B monkey-patch verified to route real `tfbs_footprinter3.ensemblrest`                                                                                                                                                                          
    calls through the cache (returned `species='homo_sapiens'`)                                                                                                                                                                                          
  - Stage D `empirical_pvalues()` numerically verified against a hand-worked                                                                                                                                                                             
    8-score distribution                                                                                                                                                                                                                                 
  - All files pass `ruff check`                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                         
  ## Next steps (not in this PR)                                                                                                                                                                                                                         
  1. Full Stage A across all 124 species (`python hpc/select_transcripts.py`)                                                                                                                                                                            
  2. Stage B run per species                                                                                                                                                                                                                             
  3. Benchmark one species' Stage C (`--benchmark` flag) to calibrate                                                                                                                                                                                    
     SLURM time/mem limits before the full array                                                                                                                                                                                                         
  4. Edit `hpc/slurm/submit.sh` `#SBATCH` lines for your cluster's partition/account                                                                                                                                                                     
  5. Full Stage C array, Stage D aggregation, Stage E upload  