### PR TITLE
Unit-test safety net for PWM, CAS p-value, and HPC aggregation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,20 @@ jobs:
       - run: pip install .
       - run: pip install wget  # runtime dep declared as pypi 'wget', install explicitly for smoke
       - run: tfbs_footprinter3 --help
+
+  test:
+    name: Unit tests / py${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: pip install .[test]
+      - run: pip install wget
+      - run: pytest tests/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,8 @@ dependencies = [
 Homepage = "https://github.com/thirtysix/TFBS_footprinting3"
 
 [project.optional-dependencies]
-# You can add optional dev/test groups here in the future
-# dev = ["check-manifest"]
-# test = ["coverage"]
+test = ["pytest>=7", "pyarrow>=10"]
+dev = ["pytest>=7", "pyarrow>=10", "ruff>=0.1"]
 
 [project.scripts]
 tfbs_footprinter3 = "tfbs_footprinter3.tfbs_footprinter3:main"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Shared pytest fixtures.
+
+Keep this file minimal — unit tests should pull their own inputs; fixtures
+here are for things that multiple suites really need.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def pwm_dict() -> dict[str, int]:
+    """The ACGT -> row-index lookup used throughout tfbs_footprinter3.
+
+    Matches the mapping the tool establishes when calling PWM_scorer
+    (nucleotide letter -> pwm row index).
+    """
+    return {"A": 0, "C": 1, "G": 2, "T": 3}
+
+
+@pytest.fixture
+def uniform_bg() -> dict[str, float]:
+    """Equal 0.25 background frequency for each base."""
+    return {"A": 0.25, "C": 0.25, "G": 0.25, "T": 0.25}

--- a/tests/test_cas_pvalue.py
+++ b/tests/test_cas_pvalue.py
@@ -1,0 +1,72 @@
+"""Unit tests for calcCombinedAffinityPvalue — the CAS p-value lookup.
+
+This is the consumer of the JSON produced by hpc/build_cas_pvalues.py and
+shipped via S3 in Stage E of the HPC pipeline. Keeping its contract pinned
+protects both the client-side lookup and the Stage D aggregation format.
+"""
+from __future__ import annotations
+
+from tfbs_footprinter3.tfbs_footprinter3 import calcCombinedAffinityPvalue
+
+
+def _build_lookup(scores_pvalues: list[tuple[float, float]]):
+    """Replicate the structure find_clusters() builds per-TF before calling.
+
+    See tfbs_footprinter3.py:1022-1026:
+        cass_with_pvalues_sorted = cas_pvalues_dict[tf_name]
+        cass_sorted = [x[0] for x in cass_with_pvalues_sorted]
+        cas_pvalues_subdict = {x[0]: x[1] for x in cass_with_pvalues_sorted}
+    """
+    cass_with_pvalues_sorted = list(scores_pvalues)
+    cass_sorted = [x[0] for x in cass_with_pvalues_sorted]
+    cas_pvalues_subdict = {x[0]: x[1] for x in cass_with_pvalues_sorted}
+    return cass_with_pvalues_sorted, cass_sorted, cas_pvalues_subdict
+
+
+class TestCalcCombinedAffinityPvalue:
+    def test_exact_hit_uses_subdict(self):
+        """When the CAS is an exact key, the subdict value is returned directly."""
+        cass_with_pvalues_sorted, cass_sorted, sub = _build_lookup([
+            (1.0, 1.0), (2.0, 0.5), (3.0, 0.1), (4.0, 0.01)
+        ])
+        result = calcCombinedAffinityPvalue(2.0, None, cass_with_pvalues_sorted, cass_sorted, sub)
+        assert result == "0.5"
+
+    def test_above_max_returns_rightmost_pvalue(self):
+        """A CAS above the largest stored score returns the right-edge p-value."""
+        cass_with_pvalues_sorted, cass_sorted, sub = _build_lookup([
+            (1.0, 1.0), (2.0, 0.5), (3.0, 0.1), (4.0, 0.01)
+        ])
+        # 5.0 is not in the table; bisect_left returns len(sorted)=4.
+        # The current implementation returns cass_with_pvalues_sorted[-1][1] = 0.01
+        # via the "else" branch (i < len-1 is false).
+        result = calcCombinedAffinityPvalue(5.0, None, cass_with_pvalues_sorted, cass_sorted, sub)
+        assert result == "0.01"
+
+    def test_below_min_returns_prefixed_pvalue(self):
+        """A CAS below the smallest stored score returns ">P(min)" (prefix ">")."""
+        cass_with_pvalues_sorted, cass_sorted, sub = _build_lookup([
+            (1.0, 1.0), (2.0, 0.5), (3.0, 0.1), (4.0, 0.01)
+        ])
+        result = calcCombinedAffinityPvalue(0.5, None, cass_with_pvalues_sorted, cass_sorted, sub)
+        # bisect_left on 0.5 returns 0 -> the "else" branch ">..." path
+        assert result == ">1.0"
+
+    def test_between_values_interpolates_via_bisect(self):
+        """Between two keys, bisect_left picks the insertion index; value at that
+        insertion-index position is returned."""
+        cass_with_pvalues_sorted, cass_sorted, sub = _build_lookup([
+            (1.0, 1.0), (2.0, 0.5), (3.0, 0.1), (4.0, 0.01)
+        ])
+        # 2.5 -> bisect_left returns 2 (insertion position for 2.5 between 2.0 and 3.0)
+        # Since index=2 > 0 and < len-1 = 3, returns cass_with_pvalues_sorted[2][1] = 0.1
+        result = calcCombinedAffinityPvalue(2.5, None, cass_with_pvalues_sorted, cass_sorted, sub)
+        assert result == "0.1"
+
+    def test_empty_distribution_is_undefined(self):
+        """Empty lookup causes a crash today — document it so refactors preserve
+        the contract: find_clusters() only calls this when tf_name is in
+        cas_pvalues_dict (tfbs_footprinter3.py:1068), so the list is non-empty."""
+        # Not asserting behavior; just pin the current pre-condition.
+        # If a future refactor tries to support empty, that's fine — update this.
+        pass

--- a/tests/test_hpc_empirical.py
+++ b/tests/test_hpc_empirical.py
@@ -1,0 +1,68 @@
+"""Unit tests for hpc/build_cas_pvalues.py empirical p-value calculation.
+
+This is the producer of the JSON that test_cas_pvalue.py's lookup consumes.
+Keeps Stage D numerically pinned so we can evolve the pipeline without
+silently shifting the p-value math.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hpc.build_cas_pvalues import empirical_pvalues
+
+
+class TestEmpiricalPvalues:
+    def test_empty_input_returns_empty(self):
+        assert empirical_pvalues([]) == []
+
+    def test_monotonic_decreasing(self):
+        """P(X >= s) is non-increasing as s increases."""
+        scores = [1.0, 2.0, 2.0, 3.0, 4.0, 4.0, 4.0, 5.0]
+        result = empirical_pvalues(scores)
+        pvs = [p for _, p in result]
+        for a, b in zip(pvs[:-1], pvs[1:], strict=True):
+            assert a >= b
+
+    def test_sorted_ascending_by_score(self):
+        """Output must be sorted by score ascending for the bisect_left lookup."""
+        scores = [5.0, 1.0, 3.0, 2.0, 4.0]
+        result = empirical_pvalues(scores)
+        scores_out = [s for s, _ in result]
+        assert scores_out == sorted(scores_out)
+
+    def test_hand_worked_distribution(self):
+        """Exact values for the 8-score fixture used in the CLI sanity check."""
+        scores = [1.0, 2.0, 2.0, 3.0, 4.0, 4.0, 4.0, 5.0]
+        result = empirical_pvalues(scores)
+        expected = {
+            1.0: 8 / 8,  # all 8 are >= 1
+            2.0: 7 / 8,  # 7 are >= 2
+            3.0: 5 / 8,  # 5 are >= 3
+            4.0: 4 / 8,  # 4 are >= 4
+            5.0: 1 / 8,  # 1 is  >= 5
+        }
+        got = dict(result)
+        for score, p in expected.items():
+            assert got[score] == pytest.approx(p)
+
+    def test_rounding_to_two_decimals(self):
+        """Scores are rounded to 2 decimals so Stage D's output aligns with
+        tfbs_footprinter3.py:1073 where CAS itself is rounded to 2 decimals."""
+        # 1.234 and 1.236 both round to 1.23 and 1.24 respectively -> distinct
+        scores = [1.234, 1.236, 1.241, 1.244]
+        result = empirical_pvalues(scores)
+        scores_out = [s for s, _ in result]
+        # 1.234 -> 1.23; 1.236 -> 1.24; 1.241 -> 1.24; 1.244 -> 1.24
+        assert 1.23 in scores_out
+        assert 1.24 in scores_out
+        # 1.23 should occur only once, 1.24 three times collapsed into one entry
+        assert len([s for s, _ in result if s == 1.24]) == 1
+
+    def test_single_value(self):
+        """Degenerate case: one score -> p=1.0 at that score."""
+        assert empirical_pvalues([2.5]) == [(2.5, 1.0)]
+
+    def test_all_identical(self):
+        """All-same distribution collapses to one entry with p=1.0."""
+        result = empirical_pvalues([3.0, 3.0, 3.0, 3.0])
+        assert result == [(3.0, 1.0)]

--- a/tests/test_pwm.py
+++ b/tests/test_pwm.py
@@ -1,0 +1,133 @@
+"""Unit tests for PWM_scorer and pwm_maker.
+
+These functions sit in tfbs_footprinter3's hottest loop (tfbs_finder calls
+PWM_scorer once per position x per TF). They are the primary target of the
+upcoming NumPy vectorization pass — these tests are the safety net that
+lets that refactor land without behavior drift.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from tfbs_footprinter3.tfbs_footprinter3 import PWM_scorer, pwm_maker
+
+# ---------- PWM_scorer ----------
+
+
+class TestPWMScorer:
+    def test_all_zero_pwm(self, pwm_dict):
+        """A zero PWM scores any sequence as 0.0."""
+        motif_length = 4
+        pwm = [[0.0] * motif_length for _ in range(4)]
+        assert PWM_scorer("ACGT", pwm, pwm_dict, "fake") == 0.0
+
+    def test_identity_contribution(self, pwm_dict):
+        """Each position contributes the matrix value at (row=nuc, col=pos)."""
+        # Design a PWM where only position 0 has non-zero values
+        pwm = [
+            [1.0, 0.0, 0.0],  # A row
+            [2.0, 0.0, 0.0],  # C row
+            [3.0, 0.0, 0.0],  # G row
+            [4.0, 0.0, 0.0],  # T row
+        ]
+        assert PWM_scorer("AAA", pwm, pwm_dict, "fake") == 1.0
+        assert PWM_scorer("CAA", pwm, pwm_dict, "fake") == 2.0
+        assert PWM_scorer("GAA", pwm, pwm_dict, "fake") == 3.0
+        assert PWM_scorer("TAA", pwm, pwm_dict, "fake") == 4.0
+
+    def test_additive_over_positions(self, pwm_dict):
+        """Total score is the sum over position contributions."""
+        pwm = [
+            [1.0, 0.5, 0.25],
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+        ]
+        assert PWM_scorer("AAA", pwm, pwm_dict, "fake") == pytest.approx(1.75)
+
+    def test_mixed_sequence(self, pwm_dict):
+        pwm = [
+            [1.0, 2.0, 3.0],  # A
+            [0.1, 0.2, 0.3],  # C
+            [0.01, 0.02, 0.03],  # G
+            [-1.0, -2.0, -3.0],  # T
+        ]
+        # ACG -> A@0=1.0 + C@1=0.2 + G@2=0.03 = 1.23
+        assert PWM_scorer("ACG", pwm, pwm_dict, "fake") == pytest.approx(1.23)
+
+    def test_single_position(self, pwm_dict):
+        pwm = [[-5.0], [10.0], [0.0], [0.0]]
+        assert PWM_scorer("C", pwm, pwm_dict, "fake") == 10.0
+        assert PWM_scorer("A", pwm, pwm_dict, "fake") == -5.0
+
+
+# ---------- pwm_maker ----------
+
+
+class TestPwmMaker:
+    """pwm_maker converts a PFM (counts matrix) to a PWM (log2 likelihood)."""
+
+    def test_balanced_motif_with_uniform_bg(self, uniform_bg):
+        """A perfectly balanced column (equal counts) at uniform bg -> 0 weight."""
+        motif_length = 2
+        # Each column has 25 of each nt -> 100 total -> equal probability 0.25
+        tf_motif = [
+            [25, 25],  # A
+            [25, 25],  # C
+            [25, 25],  # G
+            [25, 25],  # T
+        ]
+        pwm = pwm_maker("+1", motif_length, tf_motif, uniform_bg)
+        # (25 + 0.2) / (100 + 0.8) = 25.2/100.8 = 0.25 exactly -> log2(0.25/0.25) = 0
+        for row in pwm:
+            for val in row:
+                assert val == pytest.approx(0.0, abs=1e-12)
+
+    def test_shape_matches_motif(self, uniform_bg):
+        motif_length = 5
+        tf_motif = [[10] * motif_length for _ in range(4)]
+        pwm = pwm_maker("+1", motif_length, tf_motif, uniform_bg)
+        assert len(pwm) == 4
+        for row in pwm:
+            assert len(row) == motif_length
+
+    def test_skewed_column_log_likelihood(self, uniform_bg):
+        """Column with 100% A (plus pseudocount) produces expected log2 weights."""
+        motif_length = 1
+        tf_motif = [
+            [100],  # all A
+            [0],
+            [0],
+            [0],
+        ]
+        pwm = pwm_maker("+1", motif_length, tf_motif, uniform_bg)
+        # With pseudo_count = 0.8 spread uniformly (0.2 per base):
+        #   A_prob = (100 + 0.2) / (100 + 0.8) = 100.2 / 100.8
+        #   C/G/T_prob = (0 + 0.2) / (100 + 0.8) = 0.2 / 100.8
+        pseudo_count = 0.8
+        N = 100
+        expected_A = math.log((100 + pseudo_count / 4) / (N + pseudo_count) / 0.25, 2)
+        expected_other = math.log((0 + pseudo_count / 4) / (N + pseudo_count) / 0.25, 2)
+        assert pwm[0][0] == pytest.approx(expected_A)
+        assert pwm[1][0] == pytest.approx(expected_other)
+        assert pwm[2][0] == pytest.approx(expected_other)
+        assert pwm[3][0] == pytest.approx(expected_other)
+
+    def test_pwm_scorer_roundtrip(self, pwm_dict, uniform_bg):
+        """PFM -> pwm_maker -> PWM_scorer is consistent with the log2 definition."""
+        motif_length = 3
+        tf_motif = [
+            [80, 10, 30],  # A
+            [10, 70, 30],  # C
+            [5, 10, 30],  # G
+            [5, 10, 10],  # T
+        ]
+        pwm = pwm_maker("+1", motif_length, tf_motif, uniform_bg)
+        # Score the "best" motif (pick the argmax nucleotide at each col)
+        # Col 0: A=80 (max), Col 1: C=70, Col 2: A=C=G=30 (tied; pick A)
+        score_ACA = PWM_scorer("ACA", pwm, pwm_dict, "fake")
+        # Sanity: best-case score should be >= score of a random sequence
+        score_TTT = PWM_scorer("TTT", pwm, pwm_dict, "fake")
+        assert score_ACA > score_TTT


### PR DESCRIPTION
## Summary                           
  Introduces a pytest suite that pins the numerical contracts of the hottest                                                                                                                                                                             
  pure functions. This unblocks the next two PRs (monolith split,               
  PWM vectorization) to land without behavior drift.                                                                                                                                                                                                     
                                                    
  ## What's tested                                                                                                                                                                                                                                       
                                                                                
  - **`tests/test_pwm.py`** (PWM_scorer, pwm_maker)                                                                                                                                                                                                      
    Primary target of the upcoming NumPy vectorization. Covers zero/identity/
    additive/mixed cases, PFM→PWM algebra against the log2 definition, and                                                                                                                                                                               
    a roundtrip pfm_maker→PWM_scorer sanity check.                              
                                                                                                                                                                                                                                                         
  - **`tests/test_cas_pvalue.py`** (calcCombinedAffinityPvalue)
    Pins the CAS p-value lookup contract: exact hits, above-max (right-edge),                                                                                                                                                                            
    below-min (`>`-prefixed), and between-values behavior. Protects both the                                                                                                                                                                             
    client-side lookup and the sorted-tuples format Stage D produces.       
                                                                                                                                                                                                                                                         
  - **`tests/test_hpc_empirical.py`** (hpc.build_cas_pvalues.empirical_pvalues)                                                                                                                                                                          
    Empty/single/all-identical degenerate cases, sorted-ascending and                                                                                                                                                                                    
    monotonic-decreasing invariants, hand-worked 8-score distribution with                                                                                                                                                                               
    exact expected p-values, 2-decimal rounding consistency with                                                                                                                                                                                         
    `tfbs_footprinter3.py:1073`.                                                                                                                                                                                                                         
                                           
  ## Infrastructure                                                                                                                                                                                                                                      
  - `[project.optional-dependencies]` `test` and `dev` groups in pyproject.toml                                                                                                                                                                          
  - CI adds a `test` job on Python 3.11 / 3.12 running `pytest tests/ -v`                                                                                                                                                                                
                                                                                                                                                                                                                                                         
  ## Scope notes                                                                                                                                                                                                                                         
  This is a *unit-test* safety net, not an end-to-end golden test. Covering                                                                                                                                                                              
  `main()` end-to-end requires capturing ~500 MB of per-species experimental                                                                                                                                                                             
  data plus dozens of Ensembl REST responses — impractical to bundle in CI.                                                                                                                                                                              
  A future PR can add end-to-end coverage via the `CachedEnsemblClient`                                                                                                                                                                                  
  record/replay machinery already in `hpc/ensembl_cache.py`; the current                                                                                                                                                                                 
  unit tests catch the highest-risk regressions (hot-loop math) in the                                                                                                                                                                                   
  meantime.                                                           
                                                                                                                                                                                                                                                         
  ## Test plan                                                                  
  - [x] `ruff check .` clean                                                                                                                                                                                                                             
  - [x] `pytest tests/ -q` → 21 passed  