### PR TITLE
Extract ensembl module from the monolith (split PR 6/N)

### DIFF
--- a/tfbs_footprinter3/ensembl.py
+++ b/tfbs_footprinter3/ensembl.py
@@ -1,0 +1,103 @@
+"""Ensembl REST client.
+
+Thin wrapper around httplib2 with per-call retry and x-ratelimit-aware
+sleeping. Used by transcript metadata retrieval, promoter sequence
+retrieval, and regulatory overlap queries.
+
+Monkey-patch target for the HPC cache layer:
+`hpc/ensembl_cache.py::patch_tfbs_footprinter3()` assigns
+`tfbs_footprinter3.tfbs_footprinter3.ensemblrest = <cached_version>`.
+That assignment works because callers inside the monolith resolve
+`ensemblrest` via the module's globals, and the re-export binding
+exists there. If a future PR moves a caller OUT of the monolith into
+another submodule, it must either import `ensemblrest` at call time
+(via `from tfbs_footprinter3 import tfbs_footprinter3 as _tff;
+_tff.ensemblrest(...)`) OR the HPC patch must be extended to also
+rebind `tfbs_footprinter3.ensembl.ensemblrest` — pick one and document.
+
+As of v0.0.7 the 'fasta' branch here is unreached; all four call sites
+use output_type='json'. Retained verbatim during extraction so the
+behavior is preserved — a follow-up can classify transient vs fatal
+errors and drop the dead branch.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+
+import httplib2
+
+
+def ensemblrest(query_type, options, output_type, ensembl_id=None, log=False):
+    """
+    Retrieve REST data from Ensembl using provided ID, query type, and options.
+    """
+
+    http = httplib2.Http()
+    server = "http://rest.ensembl.org"
+    full_query = server + query_type + ensembl_id + options
+
+    if log:
+        logging.info(" ".join(["Ensembl REST query made:", full_query]))
+
+    success = False
+    try_count = 0
+    max_tries = 10
+    fail_sleep_time = 120
+    decoded_json = {}
+    fasta_content = []
+
+    if output_type == 'json':
+        while not success and try_count < max_tries:
+            try:
+                resp, json_data = http.request(full_query, method="GET")
+                decoded_json = json.loads(json_data)
+                ensemblrest_rate(resp)
+                try_count += 1
+                success = True
+                return decoded_json
+
+            except:
+                logging.info(" ".join(["Ensembl REST query unsuccessful, attempt:", "/".join([str(try_count), str(max_tries)]), "Sleeping:", str(fail_sleep_time), "seconds.", full_query]))
+                try_count += 1
+                print(" ".join(["Ensembl REST query unsuccessful, attempt:", "/".join([str(try_count), str(max_tries)]), "Sleeping:", str(fail_sleep_time), "seconds.", "See logfile for query."]))
+                time.sleep(fail_sleep_time)
+
+        # return empty decoded_json if max tries has elapsed
+        return decoded_json
+
+    if output_type == 'fasta':
+        while not success and try_count < max_tries:
+            try:
+                resp, fasta_content = http.request(server, method="GET", headers={"Content-Type": "text/x-fasta"})
+                ensemblrest_rate(resp)
+                try_count += 1
+                success = True
+                return fasta_content
+
+            except:
+                logging.info(" ".join(["Ensembl REST query unsuccessful, attempt:", "/".join([str(try_count), str(max_tries)]), "Sleeping:", str(fail_sleep_time), "seconds.", full_query]))
+                try_count += 1
+                print(" ".join(["Ensembl REST query unsuccessful, attempt:", "/".join([str(try_count), str(max_tries)]), "Sleeping:", str(fail_sleep_time), "seconds.", "See logfile for query."]))
+                time.sleep(fail_sleep_time)
+
+        # return empty fasta_content if max tries has elapsed
+        return fasta_content
+
+
+def ensemblrest_rate(resp):
+    """
+    Read ensembl REST headers and determine if rate-limit has been exceeded, sleep appropriately if necessary.
+    """
+
+    if int(resp['x-ratelimit-remaining']) == 0:
+        if 'Retry-After' in resp:
+            sleep_time = int(resp['Retry-After'])
+            logging.warning(" ".join(["Ensembl REST (Retry-After) requests sleeping for:", str(sleep_time)]))
+            time.sleep(sleep_time)
+
+        else:
+            sleep_time = 60
+            logging.warning(" ".join(["Ensembl REST requests sleeping for:", str(sleep_time)]))
+            time.sleep(sleep_time)

--- a/tfbs_footprinter3/tfbs_footprinter3.py
+++ b/tfbs_footprinter3/tfbs_footprinter3.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # Python vers. 3.8.0 ###########################################################
 import argparse
-import json
 import logging
 import os
 import signal
@@ -11,7 +10,6 @@ import tarfile
 import textwrap
 import time
 
-import httplib2
 import matplotlib
 import pandas as pd
 import wget
@@ -38,6 +36,7 @@ from tfbs_footprinter3.data_parsing import (  # noqa: F401
     parse_tf_ids,
     parse_transcript_ids,
 )
+from tfbs_footprinter3.ensembl import ensemblrest, ensemblrest_rate  # noqa: F401
 from tfbs_footprinter3.io_utils import (  # noqa: F401
     directory_creator,
     distance_solve,
@@ -274,78 +273,9 @@ def get_args():
 # is_online moved to tfbs_footprinter3/io_utils.py (re-exported above).
 
 
-def ensemblrest(query_type, options, output_type, ensembl_id=None, log=False):
-    """
-    Retrieve REST data from Ensembl using provided ID, query type, and options.
-    """
-
-    http = httplib2.Http()
-    server = "http://rest.ensembl.org"
-    full_query = server + query_type + ensembl_id + options
-
-    if log:
-        logging.info(" ".join(["Ensembl REST query made:", full_query]))
-
-    success = False
-    try_count = 0
-    max_tries = 10
-    fail_sleep_time = 120
-    decoded_json = {}
-    fasta_content = []
-
-    if output_type == 'json':
-        while not success and try_count < max_tries:
-            try:
-                resp, json_data = http.request(full_query, method="GET")
-                decoded_json = json.loads(json_data)
-                ensemblrest_rate(resp)
-                try_count += 1
-                success = True
-                return decoded_json
-
-            except:
-                logging.info(" ".join(["Ensembl REST query unsuccessful, attempt:", "/".join([str(try_count), str(max_tries)]), "Sleeping:", str(fail_sleep_time), "seconds.", full_query]))
-                try_count += 1
-                print(" ".join(["Ensembl REST query unsuccessful, attempt:", "/".join([str(try_count), str(max_tries)]), "Sleeping:", str(fail_sleep_time), "seconds.", "See logfile for query."]))
-                time.sleep(fail_sleep_time)
-
-        # return empty decoded_json if max tries has elapsed
-        return decoded_json
-
-    if output_type == 'fasta':
-        while not success and try_count < max_tries:
-            try:
-                resp, fasta_content = http.request(server, method="GET", headers={"Content-Type":"text/x-fasta"})
-                ensemblrest_rate(resp)
-                try_count += 1
-                success = True
-                return fasta_content
-
-            except:
-                logging.info(" ".join(["Ensembl REST query unsuccessful, attempt:", "/".join([str(try_count), str(max_tries)]), "Sleeping:", str(fail_sleep_time), "seconds.", full_query]))
-                try_count += 1
-                print(" ".join(["Ensembl REST query unsuccessful, attempt:", "/".join([str(try_count), str(max_tries)]), "Sleeping:", str(fail_sleep_time), "seconds.", "See logfile for query."]))
-                time.sleep(fail_sleep_time)
-
-        # return empty fasta_content if max tries has elapsed
-        return fasta_content
-
-
-def ensemblrest_rate(resp):
-    """
-    Read ensembl REST headers and determine if rate-limit has been exceeded, sleep appropriately if necessary.
-    """
-
-    if int(resp['x-ratelimit-remaining']) == 0:
-        if 'Retry-After' in resp:
-            sleep_time = int(resp['Retry-After'])
-            logging.warning(" ".join(["Ensembl REST (Retry-After) requests sleeping for:", str(sleep_time)]))
-            time.sleep(sleep_time)
-
-        else:
-            sleep_time = 60
-            logging.warning(" ".join(["Ensembl REST requests sleeping for:", str(sleep_time)]))
-            time.sleep(sleep_time)
+# ensemblrest and ensemblrest_rate moved to tfbs_footprinter3/ensembl.py
+# (re-exported above). The HPC cache patches tff.ensemblrest here in the
+# monolith's namespace — see hpc/ensembl_cache.py::patch_tfbs_footprinter3().
 
 
 # parse_transcript_ids, parse_tf_ids, file_to_datalist, compare_tfs_list_jaspar


### PR DESCRIPTION
## Summary                                                                    
  Moves `ensemblrest()` and `ensemblrest_rate()` into                                                                                                                                                                                                    
  `tfbs_footprinter3/ensembl.py`.                    
                                                                                                                                                                                                                                                         
  ## Monkey-patch compatibility — verified                                                                                                                                                                                                               
  The HPC cache (`hpc/ensembl_cache.py::patch_tfbs_footprinter3()`)                                                                                                                                                                                      
  rebinds `tfbs_footprinter3.tfbs_footprinter3.ensemblrest` to the                                                                                                                                                                                       
  cached wrapper. That still works after extraction because:                                                                                                                                                                                             
  - All current callers of `ensemblrest()` live in the monolith and
    resolve the name via its module globals.                                                                                                                                                                                                             
  - The re-export `from tfbs_footprinter3.ensembl import ensemblrest`                                                                                                                                                                                    
    binds the name in the monolith's namespace — which is exactly what                                                                                                                                                                                   
    the patch rewrites.                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                         
  Verified end-to-end in this PR: applied the patch, called                     
  `tff.ensemblrest(...)` live against rest.ensembl.org for 
  `ENST00000361390`, confirmed it returned `species='homo_sapiens'`                                                                                                                                                                                      
  through the cached wrapper.                                      
                                                                                                                                                                                                                                                         
  A docstring note in `ensembl.py` documents the contract: if a future          
  PR moves an `ensemblrest` caller out of the monolith, the patch target                                                                                                                                                                                 
  needs updating in lockstep (either the caller uses attribute-access at                                                                                                                                                                                 
  call time, or the patch is extended to rebind `tfbs_footprinter3.ensembl.ensemblrest` as well).                                                                                                                                                        
                                                                                                                                                                                                                                                         
  ## Impact                                                                                                                                                                                                                                              
  - Monolith: **1271 → 1201 lines** (−70)                                       
  - All 21 unit tests green                                                                                                                                                                                                                              
  - `ruff check .` clean                                                        
  - Live-tested the patched HPC path against real Ensembl                                                                                                                                                                                                
                                                                                
  ## Remaining in monolith (~1201 lines)                                                                                                                                                                                                                 
  - `experimentalDataUpdater`, `experimentaldata`, `species_specific_data` (~300 lines) — data-loader concerns                                                                                                                                           
  - `tfbs_finder`, `alignment_tools`, `retrieve_genome_aligned`, transcript/gene/regulatory metadata retrieval (~300 lines) — pipeline orchestration                                                                                                     
  - `main`, `get_args` (~300 lines) — CLI                                                                                                                                                                                                                
  - Module-level state (`script_dir`, `curdir`) + re-export block