### PR TITLE
Vectorize PWM scoring in tfbs_finder (4x speedup at default pval)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,11 @@ hpc/cache/
 hpc/cas_scores/
 hpc/artifacts/
 hpc/transcript_lists/
+
+# Experimental data downloaded at runtime by tfbs_footprinter3 -update.
+# Only the small bundled files (pwms.json, species_nt_freq.json) live in git;
+# everything else under tfbs_footprinter3/data/ is fetched from S3 on first run
+# and must NEVER be committed (can easily be >1 GB per species).
+tfbs_footprinter3/data/*
+!tfbs_footprinter3/data/pwms.json
+!tfbs_footprinter3/data/species_nt_freq.json

--- a/tests/test_pwm.py
+++ b/tests/test_pwm.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import math
 
+import numpy as np
 import pytest
 
+from tfbs_footprinter3.pwm import pwm_scan_sliding, seq_to_int_array
 from tfbs_footprinter3.tfbs_footprinter3 import PWM_scorer, pwm_maker
 
 # ---------- PWM_scorer ----------
@@ -131,3 +133,67 @@ class TestPwmMaker:
         # Sanity: best-case score should be >= score of a random sequence
         score_TTT = PWM_scorer("TTT", pwm, pwm_dict, "fake")
         assert score_ACA > score_TTT
+
+
+# ---------- pwm_scan_sliding (NumPy vectorized) ----------
+
+
+class TestPwmScanSliding:
+    """Vectorized scanner must agree exactly with the scalar PWM_scorer
+    at every window position — it's the hot path that replaces the
+    per-position inner Python loop in tfbs_finder.
+    """
+
+    def test_empty_when_seq_shorter_than_motif(self, pwm_dict):
+        seq_int = seq_to_int_array("AC", pwm_dict)
+        pwm_array = np.array([[1.0, 2.0, 3.0]] * 4)
+        scores = pwm_scan_sliding(seq_int, pwm_array)
+        assert scores.shape == (0,)
+
+    def test_single_window_matches_scalar(self, pwm_dict):
+        pwm = [
+            [1.0, 2.0, 3.0],
+            [0.1, 0.2, 0.3],
+            [0.01, 0.02, 0.03],
+            [-1.0, -2.0, -3.0],
+        ]
+        pwm_array = np.array(pwm, dtype=np.float64)
+        seq = "ACG"
+        expected = PWM_scorer(seq, pwm, pwm_dict, "fake")
+        scores = pwm_scan_sliding(seq_to_int_array(seq, pwm_dict), pwm_array)
+        assert scores.shape == (1,)
+        assert scores[0] == pytest.approx(expected)
+
+    def test_matches_scalar_at_every_position(self, pwm_dict):
+        """Run a realistic scan: random 200-nt sequence, 10-wide PWM.
+
+        Every vectorized score must equal PWM_scorer on the same window
+        to within float64 epsilon.
+        """
+        import random
+        rng = random.Random(42)
+        seq = "".join(rng.choice("ACGT") for _ in range(200))
+        motif_length = 10
+        pwm = [[rng.uniform(-3, 3) for _ in range(motif_length)] for _ in range(4)]
+        pwm_array = np.array(pwm, dtype=np.float64)
+
+        scores = pwm_scan_sliding(seq_to_int_array(seq, pwm_dict), pwm_array)
+
+        # Compare against scalar PWM_scorer at each window
+        expected = [
+            PWM_scorer(seq[i:i + motif_length], pwm, pwm_dict, "fake")
+            for i in range(len(seq) - motif_length + 1)
+        ]
+        assert len(scores) == len(expected)
+        np.testing.assert_allclose(scores, expected, rtol=1e-12, atol=1e-12)
+
+    def test_seq_to_int_array_maps_correctly(self, pwm_dict):
+        arr = seq_to_int_array("ACGTACGT", pwm_dict)
+        np.testing.assert_array_equal(arr, [0, 1, 2, 3, 0, 1, 2, 3])
+
+    def test_seq_to_int_array_marks_unknown_chars(self, pwm_dict):
+        arr = seq_to_int_array("AXN-", pwm_dict)
+        assert arr[0] == 0  # 'A'
+        assert arr[1] == -1  # 'X' not in dict
+        assert arr[2] == -1  # 'N' not in dict
+        assert arr[3] == -1  # '-' not in dict

--- a/tfbs_footprinter3/pipeline.py
+++ b/tfbs_footprinter3/pipeline.py
@@ -28,6 +28,7 @@ import time
 from bisect import bisect_left
 from operator import itemgetter
 
+import numpy as np
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
@@ -40,7 +41,7 @@ from tfbs_footprinter3.alignment import (
     remove_non_ACGT,
 )
 from tfbs_footprinter3.io_utils import dump_json, load_json
-from tfbs_footprinter3.pwm import PWM_scorer, pwm_maker
+from tfbs_footprinter3.pwm import pwm_maker, pwm_scan_sliding, seq_to_int_array
 from tfbs_footprinter3.translators import start_end_found_motif
 
 
@@ -77,6 +78,14 @@ def tfbs_finder(transcript_name, alignment, target_tfs_list, TFBS_matrix_dict, t
         forward_seq = str(entry_seqrecord.seq)
         reverse_seq = str(entry_seqrecord.seq.reverse_complement())
         seq_dict = {"+1": forward_seq, "-1": reverse_seq}
+
+        # Precompute int-encoded sequences once per strand; fancy-indexing
+        # into the PWM array during the per-TF scan uses these.
+        mononuc_pwm_dict_ndarray_compatible = {"A": 0, "C": 1, "G": 2, "T": 3}
+        seq_int_dict = {
+            strand: seq_to_int_array(seq, mononuc_pwm_dict_ndarray_compatible)
+            for strand, seq in seq_dict.items()
+        }
 
         # generate background frequencies of each mono-nucleotide for forward and reverse strands
         bg_nuc_freq_dict = {}
@@ -119,36 +128,45 @@ def tfbs_finder(transcript_name, alignment, target_tfs_list, TFBS_matrix_dict, t
                     # iterate through the forward and reverse strand sequences
                     for strand, seq in seq_dict.items():
                         pwm = pwm_maker(strand, motif_length, tf_motif, bg_nuc_freq_dict)
+                        pwm_array = np.asarray(pwm, dtype=np.float64)
 
                         seq_length = len(seq)
-                        # iterate through the nt sequence, extract a current frame based on the motif size and score
-                        for i in range(0, seq_length - motif_length):
+                        # Vectorized PWM scan: compute scores at every window
+                        # start in one NumPy operation, then iterate only over
+                        # the indices that pass the threshold. Matches the
+                        # original loop range (0, seq_length - motif_length)
+                        # by slicing to that length (sliding_window_view yields
+                        # one more window than the original iterated).
+                        seq_int = seq_int_dict[strand]
+                        all_scores = pwm_scan_sliding(seq_int, pwm_array)[:seq_length - motif_length]
+                        passing_indices = np.flatnonzero(all_scores >= tf_pwm_score_threshold)
+
+                        for i in passing_indices.tolist():
+                            current_frame_score = float(all_scores[i])
+                            current_frame_score = round(current_frame_score, 2)
+
+                            pval_index = bisect_left(scores_list_sorted, current_frame_score)
+                            if pval_index >= len(pvals_scores_list_sorted):
+                                pval_index = -1
+                            else:
+                                pval_index -= 1
+
+                            # account for pvalues which are larger than the current largest, so that they can be distinguished appropriately in the result table.
+                            if pval_index < 0:
+                                current_frame_score_pvalue = ">" + str(pvals_scores_list_sorted[0][0])
+                            else:
+                                current_frame_score_pvalue = str(pvals_scores_list_sorted[pval_index][0])
+
+                            hit_loc_start, hit_loc_end, hit_loc_before_TSS_start, hit_loc_before_TSS_end = start_end_found_motif(i, strand, seq_length, promoter_after_tss, motif_length)
+
+                            # identify position in alignment from start of found motif in unaligned sequence
+                            aligned_position = unaligned2aligned_index_dict[species][hit_loc_start]
+
+                            # materialize the window (only needed for passing hits)
                             current_frame = seq[i:i + motif_length]
-                            current_frame_score = PWM_scorer(current_frame, pwm, mononuc_pwm_dict, 'mono')
 
-                            # keep results that are above the precomputed threshold
-                            if current_frame_score >= tf_pwm_score_threshold:
-                                current_frame_score = round(current_frame_score, 2)
-
-                                pval_index = bisect_left(scores_list_sorted, current_frame_score)
-                                if pval_index >= len(pvals_scores_list_sorted):
-                                    pval_index = -1
-                                else:
-                                    pval_index -= 1
-
-                                # account for pvalues which are larger than the current largest, so that they can be distinguished appropriately in the result table.
-                                if pval_index < 0:
-                                    current_frame_score_pvalue = ">" + str(pvals_scores_list_sorted[0][0])
-                                else:
-                                    current_frame_score_pvalue = str(pvals_scores_list_sorted[pval_index][0])
-
-                                hit_loc_start, hit_loc_end, hit_loc_before_TSS_start, hit_loc_before_TSS_end = start_end_found_motif(i, strand, seq_length, promoter_after_tss, motif_length)
-
-                                # identify position in alignment from start of found motif in unaligned sequence
-                                aligned_position = unaligned2aligned_index_dict[species][hit_loc_start]
-
-                                # add to results dictionary by tf_name
-                                tfbss_found_dict[tf_name].append([current_frame, strand, hit_loc_start, hit_loc_end, hit_loc_before_TSS_start, hit_loc_before_TSS_end, current_frame_score, current_frame_score_pvalue])
+                            # add to results dictionary by tf_name
+                            tfbss_found_dict[tf_name].append([current_frame, strand, hit_loc_start, hit_loc_end, hit_loc_before_TSS_start, hit_loc_before_TSS_end, current_frame_score, current_frame_score_pvalue])
 
     end_time = time.time()
     logging.info(" ".join(["total time for tfbs_finder() for this transcript:", str(end_time - start_time), "seconds"]))

--- a/tfbs_footprinter3/pwm.py
+++ b/tfbs_footprinter3/pwm.py
@@ -1,13 +1,21 @@
 """Position weight matrix (PWM) construction and scoring.
 
-Extracted from tfbs_footprinter3.py (previously lines 772-822). These are
-the hottest pure functions in the tool — tfbs_finder() calls PWM_scorer
+Extracted from tfbs_footprinter3.py. These are the hottest pure
+functions in the tool — tfbs_finder() previously called PWM_scorer
 once per (position × TF). Pinned by the unit tests in tests/test_pwm.py;
 any refactor here must keep those tests green.
+
+`pwm_scan_sliding` is the NumPy-based fast path introduced in the
+vectorization PR. It computes PWM scores at every sliding-window
+position of a sequence in one shot, replacing the O(seq_length ×
+motif_length) inner Python loop in tfbs_finder. `PWM_scorer` is kept
+as a drop-in scalar reference (and is what the unit tests exercise).
 """
 from __future__ import annotations
 
 import math
+
+import numpy as np
 
 
 def pwm_maker(strand, motif_length, tf_motif, bg_nuc_freq_dict):
@@ -54,3 +62,42 @@ def PWM_scorer(seq, pwm, pwm_dict, pwm_type):
         seq_score += pwm[pwm_dict[seq[i:i + 1]]][i]
 
     return seq_score
+
+
+def seq_to_int_array(seq: str, pwm_dict: dict) -> np.ndarray:
+    """Map an ACGT sequence string to an int8 array of row indices.
+
+    Positions with a character that isn't in `pwm_dict` are set to -1;
+    callers should avoid scoring windows that contain -1 since such
+    windows produce garbage PWM rows.
+    """
+    arr = np.full(len(seq), -1, dtype=np.int8)
+    for char, idx in pwm_dict.items():
+        arr[np.frombuffer(seq.encode("ascii"), dtype=np.uint8) == ord(char)] = idx
+    return arr
+
+
+def pwm_scan_sliding(seq_int: np.ndarray, pwm_array: np.ndarray) -> np.ndarray:
+    """Return PWM scores at every sliding-window start position.
+
+    scores[i] = sum_j pwm_array[seq_int[i+j], j]   for j = 0 .. motif_length - 1
+
+    Equivalent to calling PWM_scorer on seq[i:i+motif_length] for every
+    i in range(0, len(seq) - motif_length + 1), but does the sum in
+    NumPy in a single fancy-indexing + sum-along-axis operation.
+
+    `seq_int` must be integer row indices (use seq_to_int_array).
+    `pwm_array` must be shape (4, motif_length), dtype float64.
+    """
+    motif_length = pwm_array.shape[1]
+    n_positions = len(seq_int) - motif_length + 1
+    if n_positions <= 0:
+        return np.empty(0, dtype=np.float64)
+
+    # Sliding windows over seq_int: shape (n_positions, motif_length)
+    windows = np.lib.stride_tricks.sliding_window_view(seq_int, motif_length)
+    # Fancy-index pwm_array at (row = windows[i, j], col = j) for all i, j.
+    col_idx = np.arange(motif_length)
+    # pwm_array[windows, col_idx] has shape (n_positions, motif_length);
+    # NumPy broadcasts col_idx across the windows axis.
+    return pwm_array[windows, col_idx].sum(axis=1)


### PR DESCRIPTION
Description:
  ## Summary                                                                                                                                                                                                                                             
  Replaces the per-position Python inner loop in `tfbs_finder()` with a
  NumPy sliding-window scan. Scalar `PWM_scorer` is kept as the reference
  implementation for unit tests and any future debugging.                                                                                                                                                                                                
                                                         
  ### New helpers in `tfbs_footprinter3/pwm.py`                                                                                                                                                                                                          
  - `seq_to_int_array(seq, pwm_dict)` — maps an ACGT string to an int8                                                                                                                                                                                   
    array of PWM row indices                                          
  - `pwm_scan_sliding(seq_int, pwm_array)` — returns scores at every                                                                                                                                                                                     
    window start via `np.lib.stride_tricks.sliding_window_view` plus a
    fancy-indexed gather-and-sum. Unit-tested to agree with `PWM_scorer`                                                                                                                                                                                 
    at every window for a 200-nt random sequence × 10-wide PWM                                                                                                                                                                                           
    (rtol/atol = 1e-12).                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                         
  ### Hot-path integration                                                                                                                                                                                                                               
  `pipeline.py:tfbs_finder` now:                                                                                                                                                                                                                         
  1. Builds per-strand int arrays once (outside the TF loop)
  2. For each TF/strand, builds `pwm_array`, calls `pwm_scan_sliding`                                                                                                                                                                                    
  3. Filters passing positions via `np.flatnonzero(scores >= threshold)`
  4. Iterates only over passing indices for p-value lookup + hit record                                                                                                                                                                                  
                                                                       
  Window count preserved: the sliding-window output is sliced to the                                                                                                                                                                                     
  same `range(0, seq_length - motif_length)` the scalar loop used.  
                                                                                                                                                                                                                                                         
  ## Measured on `sample_analysis/sample_ids.txt` (2 human transcripts)                                                                                                                                                                                  
                                                                       
  | pval | baseline `tfbs_finder` | vectorized `tfbs_finder` | speedup |                                                                                                                                                                                 
  |------|-----------------------|--------------------------|---------|                                                                                                                                                                                  
  | 1.0 (unfiltered) | 3.38 s / transcript | 2.65 s / transcript | 1.28× |
  | 0.01 (default) | 2.31 s total | **0.56 s total** | **4.1×** |                                                                                                                                                                                        
                                                                                                                                                                                                                                                         
  Wall time at `pval=0.01`: 14.4 s → 12.8 s.                                                                                                                                                                                                             
                                                                                                                                                                                                                                                         
  **Outputs byte-identical vs master at both pval settings**, verified
  via `diff` of `cluster_dict.json` and `TFBSs_found.sortedclusters.csv`.                                                                                                                                                                                
                                                                         
  ## `.gitignore`                                                                                                                                                                                                                                        
  Adds exclusions for everything under `tfbs_footprinter3/data/` except                                                                                                                                                                                  
  the two small bundled files (`pwms.json`, `species_nt_freq.json`). The
  per-species experimental data is fetched from S3 at first run and can                                                                                                                                                                                  
  easily exceed 1 GB; it must never be committed. (This PR's first push
  accidentally captured ~1 GB of that data — force-pushed out, `.gitignore`                                                                                                                                                                              
  prevents recurrence.)                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                         
  ## Tests                                                                                                                                                                                                                                               
  - 26/26 pass (21 original + 5 new vectorization tests)                                                                                                                                                                                                 
  - `ruff check .` clean