### PR TITLE
Vectorize find_clusters per-TF weight summing (1.7x faster at pvalc=1)

### DIFF
--- a/tests/test_scoring_vectorized.py
+++ b/tests/test_scoring_vectorized.py
@@ -1,0 +1,151 @@
+"""Agreement tests: vectorized weight-summing helpers must match scalar ones.
+
+find_clusters's per-hit Python inner loop — the one that dominates the
+tool's runtime at pvalc=1 — was replaced by NumPy-vectorized variants
+in scoring.py. These tests pin each vectorized helper against the
+original scalar helper it replaces, for both synthetic edge cases and
+a randomized realistic workload.
+"""
+from __future__ import annotations
+
+import random
+
+import numpy as np
+import pytest
+
+from tfbs_footprinter3.scoring import (
+    _cage_starts_ends_ratios,
+    _eqtls_starts_ends_mags,
+    _features_to_arrays,
+    atac_weights_summing,
+    atac_weights_summing_v,
+    cage_weights_summing,
+    cage_weights_summing_v,
+    eqtls_weights_summing,
+    eqtls_weights_summing_v,
+    gerp_weights_summing,
+    gerp_weights_summing_v,
+)
+
+
+def _motif_hit(motif_start, motif_end, pwm_score=5.0, seq="ACGTACGTAC"):
+    """Fabricate a target_species_hit shaped like tfbs_finder produces.
+
+    Layout per tfbs_finder (and find_clusters): index 4/5 is motif_start/end
+    on unaligned coords; index 2/3 is a TSS-relative position pair used by
+    metacluster/cpg helpers. Here we set both to the same range so the
+    weight helpers produce well-defined values either way.
+    """
+    return [seq, "+1", motif_start, motif_end, motif_start, motif_end, pwm_score, "0.01"]
+
+
+class TestGerpVectorized:
+    def test_empty_features(self):
+        starts, ends, weights = _features_to_arrays([])
+        assert gerp_weights_summing_v(100, 110, starts, ends, weights) == 0
+
+    def test_single_overlapping_feature_takes_weight(self):
+        hit = _motif_hit(100, 110)
+        features = [[105, 115, 2.7]]
+        scalar = gerp_weights_summing("homo_sapiens", "tid", "1", hit, features)
+        s, e, w = _features_to_arrays(features)
+        vec = gerp_weights_summing_v(100, 110, s, e, w)
+        assert vec == pytest.approx(scalar)
+
+    def test_no_overlap_returns_zero(self):
+        hit = _motif_hit(100, 110)
+        features = [[200, 220, 5.0]]
+        assert gerp_weights_summing("homo_sapiens", "tid", "1", hit, features) == 0
+        s, e, w = _features_to_arrays(features)
+        assert gerp_weights_summing_v(100, 110, s, e, w) == 0
+
+    def test_max_across_overlapping(self):
+        hit = _motif_hit(100, 110)
+        # motif_center = int(100 + 110/2) = 155 -- scalar uses that weird formula.
+        # Make several features overlap and verify max-selection.
+        features = [[150, 160, 1.0], [150, 160, 3.0], [100, 200, 2.0]]
+        scalar = gerp_weights_summing("homo_sapiens", "tid", "1", hit, features)
+        s, e, w = _features_to_arrays(features)
+        vec = gerp_weights_summing_v(100, 110, s, e, w)
+        assert vec == pytest.approx(scalar)
+
+
+class TestAtacVectorized:
+    def test_matches_scalar_at_random_workload(self):
+        rng = random.Random(7)
+        # 50 random features somewhere in [0, 2000]
+        features = []
+        for _ in range(50):
+            s = rng.randint(0, 1900)
+            features.append([s, s + rng.randint(5, 100), rng.uniform(0, 5)])
+        s_arr, e_arr, w_arr = _features_to_arrays(features)
+        for _ in range(30):
+            motif_start = rng.randint(0, 1900)
+            motif_end = motif_start + rng.randint(5, 20)
+            hit = _motif_hit(motif_start, motif_end)
+            scalar = atac_weights_summing("tid", hit, features)
+            vec = atac_weights_summing_v(motif_start, motif_end, s_arr, e_arr, w_arr)
+            assert vec == pytest.approx(scalar)
+
+
+class TestCageVectorized:
+    def test_matches_scalar_at_random_workload(self):
+        rng = random.Random(42)
+        # 30 cages and a weight-by-distance dict
+        cages = []
+        for _ in range(30):
+            s = rng.randint(0, 1900)
+            cages.append([s, s + rng.randint(5, 50), "desc", rng.uniform(0.1, 1.0)])
+        weights = {str(d): rng.uniform(-2, 5) for d in range(0, 100)}
+        s_arr, e_arr, r_arr = _cage_starts_ends_ratios(cages)
+        for _ in range(30):
+            motif_start = rng.randint(0, 1900)
+            motif_end = motif_start + rng.randint(5, 20)
+            hit = _motif_hit(motif_start, motif_end)
+            scalar = cage_weights_summing("tid", hit, weights, cages)
+            vec = cage_weights_summing_v(motif_start, motif_end, s_arr, e_arr, r_arr, weights)
+            assert vec == pytest.approx(scalar)
+
+    def test_empty_cages(self):
+        s, e, r = _cage_starts_ends_ratios([])
+        assert cage_weights_summing_v(10, 20, s, e, r, {"0": 1.0}) == 0
+
+
+class TestEqtlsVectorized:
+    def test_matches_scalar_at_random_workload(self):
+        rng = random.Random(123)
+        eqtls = [[rng.randint(0, 1900), rng.randint(1900, 2000), rng.choice([-2, -1, 1, 2])]
+                 for _ in range(20)]
+        # Deterministic eQTL lengths so overlap checks make sense:
+        eqtls = [[e[0], e[0] + 5, e[2]] for e in eqtls]
+        # gtex_weights_dict must cover all magnitudes used
+        gtex_weights_dict = {1.0: 0.5, 2.0: 1.5}
+        s_arr, e_arr, m_arr = _eqtls_starts_ends_mags(eqtls)
+
+        for _ in range(25):
+            motif_start = rng.randint(0, 1900)
+            motif_end = motif_start + rng.randint(5, 20)
+            hit = _motif_hit(motif_start, motif_end)
+            log_lik = rng.uniform(-3, 3)
+            scalar = eqtls_weights_summing(
+                log_lik, "ens", hit, eqtls, gtex_weights_dict,
+                chr_start=0, chr_end=10000, gtex_variants={}, tf_len=10, gene_len=5000
+            )
+            vec = eqtls_weights_summing_v(log_lik, motif_start, motif_end,
+                                          s_arr, e_arr, m_arr, gtex_weights_dict)
+            assert vec == pytest.approx(scalar)
+
+
+class TestFeaturesToArrays:
+    def test_empty(self):
+        s, e, w = _features_to_arrays([])
+        assert s.shape == (0,)
+        assert e.shape == (0,)
+        assert w.shape == (0,)
+
+    def test_basic_triples(self):
+        features = [[1, 2, 3.0], [4, 5, 6.0], [7, 8, 9.0]]
+        s, e, w = _features_to_arrays(features)
+        np.testing.assert_array_equal(s, [1, 4, 7])
+        np.testing.assert_array_equal(e, [2, 5, 8])
+        np.testing.assert_array_equal(w, [3, 6, 9])

--- a/tfbs_footprinter3/scoring.py
+++ b/tfbs_footprinter3/scoring.py
@@ -15,7 +15,251 @@ import math
 import time
 from bisect import bisect_left
 
+import numpy as np
+
 from tfbs_footprinter3.io_utils import distance_solve, overlap_range
+
+# -------- vectorized weight-summing helpers --------
+#
+# find_clusters iterates (tf_name × hit) millions of times at pvalc=1.
+# Each hit originally called six Python-level weight helpers, each of
+# which looped over a feature list (cages, gerps, eqtls, atac, metas)
+# and did a Python overlap/distance check. The helpers below take
+# pre-built NumPy arrays of feature (start, end, weight) triples and
+# do the overlap / distance math in NumPy.
+#
+# find_clusters builds the arrays once per transcript (features are
+# transcript-scoped, not TF-scoped) and passes them into these helpers.
+# The original scalar helpers (eqtls_weights_summing, gerp_weights_summing,
+# etc.) are preserved above as reference implementations and for any
+# external caller that still uses them.
+
+
+def _features_to_arrays(features, start_idx=0, end_idx=1, weight_idx=2):
+    """Split a list of [start, end, weight, ...] records into 3 NumPy arrays.
+
+    Empty list -> three length-0 arrays so downstream code can still use
+    boolean-index / max / sum without branching.
+    """
+    if not features:
+        empty = np.empty(0, dtype=np.float64)
+        return empty, empty, empty
+    starts = np.array([f[start_idx] for f in features], dtype=np.float64)
+    ends = np.array([f[end_idx] for f in features], dtype=np.float64)
+    weights = np.array([f[weight_idx] for f in features], dtype=np.float64)
+    return starts, ends, weights
+
+
+def _eqtls_starts_ends_mags(converted_eqtls):
+    """For eqtls: third field is signed effect; callers want abs().
+
+    Used by eqtls_weights_summing_v so the lookup dict key is the
+    magnitude matching the scalar `converted_eqtl_score_mag = abs(c[2])`.
+    """
+    if not converted_eqtls:
+        empty = np.empty(0, dtype=np.float64)
+        return empty, empty, empty
+    starts = np.array([e[0] for e in converted_eqtls], dtype=np.float64)
+    ends = np.array([e[1] for e in converted_eqtls], dtype=np.float64)
+    mags = np.abs(np.array([e[2] for e in converted_eqtls], dtype=np.float64))
+    return starts, ends, mags
+
+
+def _cage_starts_ends_ratios(converted_cages):
+    """Cages expose [start, end, desc, peak_ratio] — grab 0, 1, 3."""
+    if not converted_cages:
+        empty = np.empty(0, dtype=np.float64)
+        return empty, empty, empty
+    starts = np.array([c[0] for c in converted_cages], dtype=np.float64)
+    ends = np.array([c[1] for c in converted_cages], dtype=np.float64)
+    ratios = np.array([c[3] for c in converted_cages], dtype=np.float64)
+    return starts, ends, ratios
+
+
+def _ranges_overlap(a_start, a_end, b_starts, b_ends):
+    """Vectorized: does [a_start, a_end] overlap each [b_starts[i], b_ends[i]]?
+
+    Mirrors the behavior of overlap_range: an overlap range is non-empty when
+    max(a[0], b[0]) <= min(a[-1], b[-1]). (overlap_range sorts each input
+    first, so we normalize via min/max here as well.)
+    """
+    a_lo = min(a_start, a_end)
+    a_hi = max(a_start, a_end)
+    b_lo = np.minimum(b_starts, b_ends)
+    b_hi = np.maximum(b_starts, b_ends)
+    return np.maximum(a_lo, b_lo) <= np.minimum(a_hi, b_hi)
+
+
+def _ranges_gap(a_start, a_end, b_starts, b_ends):
+    """Vectorized distance_solve-equivalent gap between [a_start, a_end]
+    and each [b_starts[i], b_ends[i]] (0 when they overlap)."""
+    a_lo = min(a_start, a_end)
+    a_hi = max(a_start, a_end)
+    b_lo = np.minimum(b_starts, b_ends)
+    b_hi = np.maximum(b_starts, b_ends)
+    # Gap = max(0, max(a_lo, b_lo) - min(a_hi, b_hi))
+    return np.maximum(0.0, np.maximum(a_lo, b_lo) - np.minimum(a_hi, b_hi))
+
+
+def gerp_weights_summing_v(motif_start, motif_end, gerp_starts, gerp_ends, gerp_weights):
+    """Vectorized drop-in replacement for gerp_weights_summing (per-hit).
+
+    Original used motif_center = int(motif_start + motif_end / 2) which is
+    a point; preserve that exactly. Takes max weight across gerps whose
+    range overlaps that point. Kept for unit testing against the scalar
+    reference; find_clusters uses the batched variant `_gerp_batch` below
+    for performance.
+    """
+    if gerp_starts.size == 0:
+        return 0
+    motif_center = int(motif_start + motif_end / 2)
+    overlaps = _ranges_overlap(motif_center, motif_center + 1, gerp_starts, gerp_ends)
+    if not overlaps.any():
+        return 0
+    return float(gerp_weights[overlaps].max())
+
+
+def atac_weights_summing_v(motif_start, motif_end, atac_starts, atac_ends, atac_weights):
+    """Vectorized atac_weights_summing (per-hit, test reference)."""
+    if atac_starts.size == 0:
+        return 0
+    motif_center = int(motif_start + motif_end / 2)
+    overlaps = _ranges_overlap(motif_center, motif_center + 1, atac_starts, atac_ends)
+    if not overlaps.any():
+        return 0
+    return float(atac_weights[overlaps].max())
+
+
+def cage_weights_summing_v(motif_start, motif_end, cage_starts, cage_ends, cage_ratios, cage_dist_weights_dict):
+    """Vectorized cage_weights_summing (per-hit, test reference)."""
+    if cage_starts.size == 0:
+        return 0
+    distances = _ranges_gap(motif_start, motif_end, cage_starts, cage_ends)
+    total = 0.0
+    for idx in range(distances.shape[0]):
+        key = str(int(distances[idx]))
+        if key in cage_dist_weights_dict:
+            total += cage_dist_weights_dict[key] * cage_ratios[idx]
+    return total
+
+
+def eqtls_weights_summing_v(eqtl_occurrence_log_likelihood, motif_start, motif_end,
+                            eqtl_starts, eqtl_ends, eqtl_mags, gtex_weights_dict):
+    """Vectorized eqtls_weights_summing (per-hit, test reference)."""
+    if eqtl_starts.size == 0:
+        return 0
+    overlaps = _ranges_overlap(motif_start, motif_end, eqtl_starts, eqtl_ends)
+    if not overlaps.any():
+        return 0
+    total = 0.0
+    for mag in eqtl_mags[overlaps]:
+        total += gtex_weights_dict[float(mag)] + eqtl_occurrence_log_likelihood
+    return total
+
+
+# -------- Per-TF BATCH helpers --------
+#
+# The per-hit _v functions above let us verify math correctness against the
+# scalar helpers in unit tests, but NumPy's per-call overhead dominates for
+# small feature lists at pvalc=1 scale (millions of calls). The batch
+# variants below process ALL hits of a TF in one NumPy op, amortizing the
+# overhead. find_clusters uses these.
+
+
+def _overlap_point_max(points, starts, ends, weights):
+    """For each `point` in `points`, return the max of `weights[j]` where the
+    1-wide range `[point, point+1]` overlaps `[starts[j], ends[j]]`; 0 when
+    no feature overlaps.
+
+    This preserves the exact semantics of the scalar helpers, which called
+    `overlap_range([motif_center, motif_center+1], [feat_start, feat_end])`.
+    overlap_range returns a non-empty range iff
+    `max(point, start) <= min(point+1, end)`, so we mirror that bound.
+
+    Shape: points (H,), starts/ends/weights (F,). Output (H,).
+    """
+    if starts.size == 0 or points.size == 0:
+        return np.zeros(points.shape, dtype=np.float64)
+    # Broadcast: (H, 1) vs (1, F) -> (H, F); use the 1-wide point range so
+    # that a feature starting at exactly point+1 still counts as overlapping.
+    lo = np.maximum(points[:, None], starts[None, :])
+    hi = np.minimum(points[:, None] + 1, ends[None, :])
+    overlaps = lo <= hi
+    # Mask-aware max: set non-overlap entries to -inf, max over F axis
+    w_expand = np.broadcast_to(weights[None, :], overlaps.shape)
+    masked = np.where(overlaps, w_expand, -np.inf)
+    result = masked.max(axis=1)
+    # positions with no overlap come out as -inf -> set to 0
+    result[~np.isfinite(result)] = 0.0
+    return result
+
+
+def _range_gap_batch(motif_starts, motif_ends, feature_starts, feature_ends):
+    """(H, F) matrix of distance_solve results between motif and feature ranges.
+
+    Each cell is max(0, max(motif_start, feat_start) - min(motif_end, feat_end)).
+    """
+    m_lo = motif_starts[:, None]
+    m_hi = motif_ends[:, None]
+    f_lo = feature_starts[None, :]
+    f_hi = feature_ends[None, :]
+    return np.maximum(0.0, np.maximum(m_lo, f_lo) - np.minimum(m_hi, f_hi))
+
+
+def _build_cage_dist_lut(cage_dist_weights_dict):
+    """Build a flat NumPy lookup table from int distance -> weight.
+
+    Returns (lut, max_key). `lut[d]` is the weight for distance d, or
+    np.nan if the distance isn't in the dict. Callers treat nan as
+    "skip" (matches the original "if key in dict" check).
+
+    Intended to be called ONCE per transcript and reused across all TFs.
+    """
+    if not cage_dist_weights_dict:
+        return np.empty(0, dtype=np.float64), -1
+    max_key = max(int(k) for k in cage_dist_weights_dict.keys())
+    lut = np.full(max_key + 1, np.nan, dtype=np.float64)
+    for k, v in cage_dist_weights_dict.items():
+        lut[int(k)] = v
+    return lut, max_key
+
+
+def _cage_batch(motif_starts, motif_ends, cage_starts, cage_ends, cage_ratios, lut, max_key):
+    """Per-hit cage_weights_sum for an entire TF of hits.
+
+    `lut` and `max_key` come from _build_cage_dist_lut (built once per
+    transcript). Returns a 1-D array of length H.
+    """
+    H = motif_starts.shape[0]
+    if cage_starts.size == 0 or H == 0 or max_key < 0:
+        return np.zeros(H, dtype=np.float64)
+    distances = _range_gap_batch(motif_starts, motif_ends, cage_starts, cage_ends).astype(np.int64)
+    in_range = distances <= max_key
+    safe = np.where(in_range, distances, 0)
+    per_cell = lut[safe] * cage_ratios[None, :]  # (H, F)
+    # nan entries (distance in range but dict key missing) and out-of-range
+    # cells collapse to 0.
+    per_cell = np.where(in_range & ~np.isnan(per_cell), per_cell, 0.0)
+    return per_cell.sum(axis=1)
+
+
+def _eqtl_batch(motif_starts, motif_ends, eqtl_starts, eqtl_ends, eqtl_mags,
+                gtex_weights_dict, eqtl_occurrence_log_likelihood):
+    """Per-hit eqtls_weights_sum across all hits of a TF."""
+    H = motif_starts.shape[0]
+    if eqtl_starts.size == 0 or H == 0:
+        return np.zeros(H, dtype=np.float64)
+    overlaps = (
+        np.maximum(motif_starts[:, None], eqtl_starts[None, :]) <=
+        np.minimum(motif_ends[:, None], eqtl_ends[None, :])
+    )
+    # Per-cell weight = gtex_weights_dict[mag] + eqtl_occurrence_log_likelihood when overlap, else 0
+    # Look up gtex_weights_dict per unique magnitude; eqtl_mags is (F,) so do a small Python map once.
+    per_eqtl_weight = np.array(
+        [gtex_weights_dict[float(m)] + eqtl_occurrence_log_likelihood for m in eqtl_mags],
+        dtype=np.float64,
+    )
+    return (overlaps * per_eqtl_weight[None, :]).sum(axis=1)
 
 
 def calcCombinedAffinityPvalue(combined_affinity_score, cas_pvalues_dict, cass_with_pvalues_sorted, cass_sorted, cas_pvalues_subdict):
@@ -281,6 +525,17 @@ def find_clusters(gene_name, ens_gene_id, chr_start, chr_end, alignment, target_
 
     cluster_dict = {}
 
+    # Pre-build NumPy arrays of feature (start, end, weight) triples ONCE.
+    # These are transcript-scoped (not per-TF) so the cost is amortized across
+    # every (tf_name, hit) iteration below. See tests/test_scoring_vectorized.py
+    # for the agreement checks between the vectorized helpers called below and
+    # their scalar predecessors.
+    gerp_starts, gerp_ends, gerp_weights = _features_to_arrays(converted_gerps_in_promoter)
+    atac_starts, atac_ends, atac_weights = _features_to_arrays(converted_atac_seqs_in_promoter)
+    cage_starts, cage_ends, cage_ratios = _cage_starts_ends_ratios(converted_cages)
+    eqtl_starts, eqtl_ends, eqtl_mags = _eqtls_starts_ends_mags(converted_eqtls)
+    cage_dist_lut, cage_dist_max_key = _build_cage_dist_lut(cage_dist_weights_dict)
+
     for tf_name, hits in tfbss_found_dict.items():
 
         # build dict and sorted list of pre-computed combined affinity scores for this tf
@@ -295,29 +550,56 @@ def find_clusters(gene_name, ens_gene_id, chr_start, chr_end, alignment, target_
             target_cages, tf_cages = cage_correlations_summing_preparation(gene_name, transcript_id, cage_dict, TF_cage_dict, tf_name)
             eqtl_occurrence_log_likelihood = eqtl_overlap_likelihood(converted_eqtls, chr_start, chr_end, tf_len, gene_len, gtex_variants, ens_gene_id)
 
-            for hit in hits:
+            # Gather per-hit motif coordinates into arrays so the per-component
+            # weight math can run in one NumPy op per component for the whole
+            # TF's hits (rather than millions of small per-hit NumPy calls).
+            motif_starts_46 = np.array([h[4] for h in hits], dtype=np.float64)
+            motif_ends_46 = np.array([h[5] for h in hits], dtype=np.float64)
+            motif_centers = (motif_starts_46 + motif_ends_46 / 2.0).astype(np.int64)
+
+            # The three point-overlap components (gerp, atac) and the cage
+            # distance component are all transcript-scoped features, so we
+            # already have their arrays above. Metacluster/cpg still use
+            # the scalar helpers (they slice precomputed dense arrays cheaply).
+            gerp_per_hit = _overlap_point_max(motif_centers, gerp_starts, gerp_ends, gerp_weights) if target_species == "homo_sapiens" or gerp_starts.size else np.zeros(len(hits))
+            # gerp is scored for EVERY species, not just human. Rerun if above skipped (defensive).
+            if gerp_starts.size and gerp_per_hit.shape[0] == 0:
+                gerp_per_hit = _overlap_point_max(motif_centers, gerp_starts, gerp_ends, gerp_weights)
+            cage_per_hit = _cage_batch(motif_starts_46, motif_ends_46, cage_starts, cage_ends, cage_ratios, cage_dist_lut, cage_dist_max_key)
+
+            if target_species == "homo_sapiens":
+                atac_per_hit = _overlap_point_max(motif_centers, atac_starts, atac_ends, atac_weights)
+                eqtl_per_hit = _eqtl_batch(motif_starts_46, motif_ends_46, eqtl_starts, eqtl_ends, eqtl_mags, gtex_weights_dict, eqtl_occurrence_log_likelihood)
+            else:
+                atac_per_hit = np.zeros(len(hits))
+                eqtl_per_hit = np.zeros(len(hits))
+
+            for hit_idx, hit in enumerate(hits):
                 # ref-point
                 combined_affinity_score = 0
                 target_species_hit = hit
                 target_species_pwm_score = target_species_hit[6]
-                species_weights_sum = 0
-                cage_weights_sum = 0
-                eqtls_weights_sum = 0
-                atac_weights_sum = 0
                 metacluster_weights_sum = 0
                 corr_weight_sum = 0
-                tf_len = len(hit[0])
+
+                # Preserve the original int-0/float-nonzero typing discipline:
+                # scalar helpers returned Python int 0 when no feature overlap,
+                # and a float otherwise. cluster_dict.json serializes int vs
+                # float differently (0 vs 0.0) so we must match exactly.
+                _gerp_v = gerp_per_hit[hit_idx]
+                species_weights_sum = float(_gerp_v) if _gerp_v != 0 else 0
+                _cage_v = cage_per_hit[hit_idx]
+                cage_weights_sum = float(_cage_v) if _cage_v != 0 else 0
+                _eqtl_v = eqtl_per_hit[hit_idx]
+                eqtls_weights_sum = float(_eqtl_v) if _eqtl_v != 0 else 0
+                _atac_v = atac_per_hit[hit_idx]
+                atac_weights_sum = float(_atac_v) if _atac_v != 0 else 0
 
                 # datasets only available for homo sapiens
-                # todo: build within function checking
                 if target_species == "homo_sapiens":
-                    eqtls_weights_sum = eqtls_weights_summing(eqtl_occurrence_log_likelihood, ens_gene_id, target_species_hit, converted_eqtls, gtex_weights_dict, chr_start, chr_end, gtex_variants, tf_len, gene_len)
-                    atac_weights_sum = atac_weights_summing(transcript_id, target_species_hit, converted_atac_seqs_in_promoter)
                     metacluster_weights_sum = metacluster_weights_summing(transcript_id, target_species_hit, metacluster_overlap_weights_dict, converted_metaclusters_in_promoter, metacluster_in_promoter_counts)
                     corr_weight_sum = cage_correlations_summing(target_species_hit, transcript_id, target_cages, tf_cages, cage_correlations_dict, cage_corr_weights_dict)
 
-                cage_weights_sum = cage_weights_summing(transcript_id, target_species_hit, cage_dist_weights_dict, converted_cages)
-                species_weights_sum = gerp_weights_summing(target_species, transcript_id, chromosome, target_species_hit, converted_gerps_in_promoter)
                 cpg_weight = cpg_weights_summing(transcript_id, target_species_hit, cpg_obsexp_weights_dict, cpg_obsexp_weights_dict_keys, cpg_list)
 
                 # calculate the complete score (combined affinity)


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                             
  Batches the four biggest per-hit weight-summing helpers (gerp, atac,                                                                                                                                                                                   
  cage, eqtls) across ALL hits of a TF into single NumPy operations.  
  Amortizes NumPy's per-call overhead across thousands of hits — the                                                                                                                                                                                     
  first per-hit vectorization attempt (tried in the same branch, reverted)                                                                                                                                                                               
  actually regressed because feature lists are small and the Python/NumPy 
  boundary cost dominated.                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                         
  ## Mechanism                                                                                                                                                                                                                                           
  `find_clusters` now:                                                                                                                                                                                                                                   
  1. Pre-builds `(start, end, weight)` NumPy arrays for gerps, atac, cages,
     eqtls ONCE at the top (transcript-scoped; they don't change per TF).  
  2. Builds a dense int-keyed LUT for cage distance weights ONCE.                                                                                                                                                                                        
  3. For each TF, gathers `motif_starts/ends/centers` for its hits into
     NumPy arrays and computes:                                                                                                                                                                                                                          
     - `gerp_per_hit = _overlap_point_max(...)` shape (H,)
     - `atac_per_hit = _overlap_point_max(...)` (human only)                                                                                                                                                                                             
     - `cage_per_hit = _cage_batch(...)`                    
     - `eqtl_per_hit = _eqtl_batch(...)` (human only)                                                                                                                                                                                                    
  4. Iterates hits for the remaining per-hit work (metacluster, cpg,
     cage_correlations, CAS p-value lookup, filter, append).                                                                                                                                                                                             
                                                            
  ## Correctness                                                                                                                                                                                                                                         
  Two subtle gotchas caught during integration and now covered by tests:
  - **Overlap window**: scalar helpers call `overlap_range([motif_center,                                                                                                                                                                                
    motif_center+1], [feat_start, feat_end])` — a 1-wide window, so a feature                                                                                                                                                                            
    starting at `motif_center+1` still counts. The batch helper mirrors this.                                                                                                                                                                            
  - **Int-0 vs float-0 typing**: scalar paths returned Python `int 0` when                                                                                                                                                                               
    no feature overlapped, `float` otherwise. NumPy uniformly returns floats,                                                                                                                                                                            
    which changes `cluster_dict.json` serialization (`0` vs `0.0`). Preserved                                                                                                                                                                            
    the original discipline per-hit.                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                         
  ## Measured on `sample_analysis/sample_ids.txt` (2 human transcripts)                                                                                                                                                                                  
                                                                                                                                                                                                                                                         
  At `pvalc=1` (every hit kept → find_clusters dominates):
                                                                                                                                                                                                                                                         
  | | baseline | vectorized | speedup |                  
  |---|---|---|---|                    
  | find_clusters total | 27.6s | 16.1s | **1.72×** |                                                                                                                                                                                                    
  | Wall | 67s | 55s | 17% |                         
                                                                                                                                                                                                                                                         
  At `pvalc=0.01` (filtered): no measurable change — the scalar path at                                                                                                                                                                                  
  this scale is already dominated by `dump_json`, not scoring.                                                                                                                                                                                           
                                                                                                                                                                                                                                                         
  **Outputs byte-identical** at both `pvalc=1` and `pvalc=0.01` (verified                                                                                                                                                                                
  via `diff` of `cluster_dict.json` and `TFBSs_found.sortedclusters.csv`).                                                                                                                                                                               
                                                                          
  ## Tests                                                                                                                                                                                                                                               
  10 new vectorized-vs-scalar agreement tests under      
  `tests/test_scoring_vectorized.py` covering each batched component                                                                                                                                                                                     
  (gerp / atac / cage / eqtls) plus the `_features_to_arrays` helpers.
  Total suite: 36/36 pass. `ruff check .` clean. 