### PR TITLE
Lazy-import matplotlib: defer ~1.5s matplotlib import to first figure call

### DIFF
--- a/tfbs_footprinter3/plotting.py
+++ b/tfbs_footprinter3/plotting.py
@@ -4,9 +4,10 @@ Renders the final promoter figure (predicted TFBSs, conservation, CpG,
 eQTLs, metaclusters, ATAC-Seq, CAGE, and TF-expression correlation tracks)
 to SVG via matplotlib.
 
-Extracted from tfbs_footprinter3.py. Matplotlib's non-interactive Agg
-backend is selected at module import time so the monolith and any future
-caller doesn't need to remember to set it before importing pyplot.
+Matplotlib is a large (~1.5s) import; we defer it to the first call to
+plot_promoter/plot_promoter_all via `_ensure_matplotlib_loaded()`. This
+keeps `tfbs_footprinter3 --help`, `-no`, and HPC runs (which pass `-no`)
+from paying the import cost.
 """
 from __future__ import annotations
 
@@ -14,14 +15,31 @@ import math
 import os
 from operator import itemgetter
 
-import matplotlib
+# Module-level placeholders populated by _ensure_matplotlib_loaded().
+# Type as Any so callers aren't bothered by the None-init pattern.
+plt = None  # matplotlib.pyplot
+mpl = None  # pylab.mpl
+numpyrandom = None  # numpy.random
 
-matplotlib.use("Agg")
 
-# Import order matters: matplotlib.use() must precede pyplot import.
-import matplotlib.pyplot as plt  # noqa: E402
-from numpy import random as numpyrandom  # noqa: E402
-from pylab import mpl  # noqa: E402
+def _ensure_matplotlib_loaded():
+    """Lazily import matplotlib + pylab + numpy.random on first figure call.
+
+    Matplotlib's Agg backend is selected BEFORE the pyplot import, so any
+    prior import of pyplot in the process wins over this. In practice the
+    tool never imports pyplot elsewhere.
+    """
+    global plt, mpl, numpyrandom
+    if plt is not None:
+        return
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as _plt
+    from numpy import random as _numpyrandom
+    from pylab import mpl as _mpl
+    plt = _plt
+    mpl = _mpl
+    numpyrandom = _numpyrandom
 
 
 def plot_promoter(target_species, transcript_id, species_group, alignment, alignment_len, promoter_before_tss, promoter_after_tss, transcript_name, top_x_greatest_hits_dict, target_dir, converted_reg_dict, converted_gerps_in_promoter, cpg_list, converted_cages, converted_metaclusters_in_promoter, converted_atac_seqs_in_promoter, converted_eqtls):
@@ -29,6 +47,7 @@ def plot_promoter(target_species, transcript_id, species_group, alignment, align
     Plot the predicted TFBSs, onto a 5000 nt promoter graph, which possess support above the current strand threshold.
     ['binding_prot', 'species', 'motif', 'strand', 'start', 'end', 'TSS-relative start', 'TSS-relative end', 'PWM score', 'p-value', 'pos in align.', 'combined affinity score', 'support']
     """
+    _ensure_matplotlib_loaded()
 
     # set axes for human
     if target_species == "homo_sapiens":
@@ -363,6 +382,7 @@ def plot_promoter_all(target_species, transcript_id, species_group, alignment, a
     Plot the predicted TFBSs, onto a 5000 nt promoter graph, which possess support above the current strand threshold.
     ['binding_prot', 'species', 'motif', 'strand', 'start', 'end', 'TSS-relative start', 'TSS-relative end', 'PWM score', 'p-value', 'pos in align.', 'combined affinity score', 'support']
     """
+    _ensure_matplotlib_loaded()
 
     if target_species == "homo_sapiens":
         fig = plt.figure(figsize=(10, 6))


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                             
  `matplotlib` was loaded at `plotting` module import time. `cli.py`
  unconditionally imports `plot_promoter`, so every CLI invocation paid
  the matplotlib import cost — even `--help`, `-no`, and HPC runs that                                                                                                                                                                                   
  never render a figure.                                              
                                                                                                                                                                                                                                                         
  This moves the `matplotlib` + `pylab` + `numpy.random` imports into a
  `_ensure_matplotlib_loaded()` helper that `plot_promoter` /                                                                                                                                                                                            
  `plot_promoter_all` call on first entry. `plotting.py`'s top-level
  imports stay cheap; matplotlib loads lazily only on actual figure                                                                                                                                                                                      
  rendering.                                                                                                                                                                                                                                             
            
  ## Measured                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                         
  | | wall | user |
  |---|---|---|                                                                                                                                                                                                                                          
  | `tfbs_footprinter3 --help` before | 0.75s | 2.28s |  
  | `tfbs_footprinter3 --help` after | **0.49s** | **1.86s** |
                                                                                                                                                                                                                                                         
  `-no` and HPC runs (which always pass `-no`) no longer pay the
  matplotlib import cost at all. Figure runs are unchanged — they just                                                                                                                                                                                   
  pay the import cost at the point of first `plot_promoter()` rather  
  than at `cli` import.                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                         
  ## Verified
  - `matplotlib` absent from `sys.modules` after `from tfbs_footprinter3 import cli` (confirmed via a live check).                                                                                                                                       
  - Figure generation on `sample_ids.txt` still produces the expected `.svg` per transcript.                      
  - Agg backend is selected inside `_ensure_matplotlib_loaded()` BEFORE `pyplot` is imported (same backend-setup contract as before).                                                                                                                    
  - 41/41 unit tests pass, ruff clean.