### PR TITLE
Feat/hpc gtf pilot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ hpc/cache/
 hpc/cas_scores/
 hpc/artifacts/
 hpc/transcript_lists/
+hpc/ensembl_gtfs/
 
 # Experimental data downloaded at runtime by tfbs_footprinter3 -update.
 # Only the small bundled files (pwms.json, species_nt_freq.json) live in git;

--- a/hpc/build_human_cas_thresholds.py
+++ b/hpc/build_human_cas_thresholds.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Concatenate the per-TF human CAS threshold TSVs from the research archive
+into the single gzipped artifact the tool will load at runtime.
+
+Reads:  <summaries_dir>/*.CAS_pvalue_score.tsv
+Writes: <out_dir>/homo_sapiens/homo_sapiens.CAS_thresholds.jaspar_2018.tsv.gz
+
+Each input TSV already carries `tf_name\tp_value\tscore` rows across the
+same p-value grid that hpc/puhti/build_cas_distributions.py emits for
+non-human species, so this script is a straight concatenation: strip the
+header from files 2..N, gzip the result.
+
+Usage:
+    python hpc/build_human_cas_thresholds.py \\
+        --summaries-dir /path/to/pwm_results_summaries \\
+        --out-dir hpc/artifacts
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import logging
+import sys
+from pathlib import Path
+
+
+def build(summaries_dir: Path, out_dir: Path) -> dict:
+    tsv_files = sorted(summaries_dir.glob("*.CAS_pvalue_score.tsv"))
+    if not tsv_files:
+        raise FileNotFoundError(f"no *.CAS_pvalue_score.tsv under {summaries_dir}")
+    logging.info("found %d per-TF TSVs", len(tsv_files))
+
+    out_species_dir = out_dir / "homo_sapiens"
+    out_species_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_species_dir / "homo_sapiens.CAS_thresholds.jaspar_2018.tsv.gz"
+
+    rows_written = 0
+    with gzip.open(out_path, "wt") as out:
+        out.write("tf_name\tp_value\tscore\n")
+        for i, path in enumerate(tsv_files, 1):
+            with open(path) as f:
+                header = f.readline()
+                if header.strip() != "tf_name\tp_value\tscore":
+                    raise ValueError(f"unexpected header in {path}: {header!r}")
+                for line in f:
+                    out.write(line)
+                    rows_written += 1
+            if i % 100 == 0 or i == len(tsv_files):
+                logging.info("  %d/%d TFs merged", i, len(tsv_files))
+    logging.info("wrote %s (%d rows across %d TFs)", out_path, rows_written, len(tsv_files))
+    return {"out": str(out_path), "tfs": len(tsv_files), "rows": rows_written}
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--summaries-dir", type=Path, required=True,
+                   help="Directory containing per-TF *.CAS_pvalue_score.tsv files.")
+    p.add_argument("--out-dir", type=Path, default=Path("hpc/artifacts"),
+                   help="Where to write the aggregated artifact (default: hpc/artifacts).")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    build(args.summaries_dir, args.out_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hpc/ensembl_gtf.py
+++ b/hpc/ensembl_gtf.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Download and parse Ensembl release-113 GTF files, pick candidate transcripts.
+
+Used by Stage A of the non-human CAS-distribution campaign:
+
+  1. For each target species (slug in Ensembl's lowercase convention),
+     download the release-113 GTF once and cache it under
+     hpc/ensembl_gtfs/<species>.gtf.gz.
+  2. Parse the GTF for protein-coding transcripts that carry
+     'tag "Ensembl_canonical"'. Record (transcript_id, chromosome).
+  3. Sample N transcripts (default 100) spread across up to K distinct
+     chromosomes (default 10). The emitted order is shuffled -- the
+     downstream pre-sort in cli.py clusters them again by chromosome
+     before the main loop runs, so transcript-file order only affects
+     reproducibility, not wall time.
+
+Why GTF instead of Ensembl BioMart (used by the earlier
+select_transcripts.py): BioMart throws transient 'Could not connect to
+mysql database' errors that force retry loops and slow the full 316-
+species fetch. GTF is a single FTP download per species, no retry logic
+needed, and pins us to a specific release (important because the tool's
+experimental-data bucket is built against Ensembl 113).
+
+Usage:
+    # Download + select for one species
+    python hpc/ensembl_gtf.py --species acanthochromis_polyacanthus \\
+        --n 100 --max-chromosomes 10
+
+    # Batch mode: all 316 species
+    python hpc/ensembl_gtf.py --species-file /tmp/species_316.txt --n 100
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import logging
+import random
+import re
+import sys
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+
+ENSEMBL_RELEASE = 113
+ENSEMBL_FTP_BASE = f"https://ftp.ensembl.org/pub/release-{ENSEMBL_RELEASE}/gtf"
+
+# GTF attribute extractors. The attribute column is a semicolon-separated
+# string of key "value"; pairs. Using specific regex (faster than a full
+# parse) for just the fields we need.
+_ATTR_BIOTYPE = re.compile(r'biotype "([^"]+)"')
+_ATTR_TRANSCRIPT_ID = re.compile(r'transcript_id "([^"]+)"')
+_ATTR_TAG_CANONICAL = re.compile(r'tag "Ensembl_canonical"')
+
+
+def _ensembl_gtf_url(species: str) -> str:
+    """Find the GTF URL for a species by listing the Ensembl FTP directory.
+
+    Ensembl's filename embeds the assembly name (e.g.
+    Acanthochromis_polyacanthus.ASM210954v1.113.gtf.gz), which varies by
+    species. We hit the directory index and regex out the expected file.
+    """
+    dir_url = f"{ENSEMBL_FTP_BASE}/{species}/"
+    req = urllib.request.Request(dir_url, headers={"User-Agent": "tfbs_footprinter3-hpc/0.0"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        html = resp.read().decode("utf-8", errors="replace")
+    species_cap = species[0].upper() + species[1:]
+    # Exclude .abinitio, .chr, .chr_patch_hapl_scaff variants -- we want the plain species.assembly.113.gtf.gz
+    pattern = re.compile(rf'"({re.escape(species_cap)}\.[A-Za-z0-9_.\-]+\.{ENSEMBL_RELEASE}\.gtf\.gz)"')
+    matches = [m.group(1) for m in pattern.finditer(html)]
+    # Prefer the shortest filename (which is the plain .113.gtf.gz, not .chr_patch_hapl_scaff.113.gtf.gz etc.)
+    if not matches:
+        raise RuntimeError(f"no Ensembl {ENSEMBL_RELEASE} GTF found for {species!r} at {dir_url}")
+    matches.sort(key=len)
+    return dir_url + matches[0]
+
+
+def download_gtf(species: str, cache_dir: Path) -> Path:
+    """Download the Ensembl 113 GTF for `species` (cached)."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    out_path = cache_dir / f"{species}.gtf.gz"
+    if out_path.exists() and out_path.stat().st_size > 0:
+        return out_path
+    url = _ensembl_gtf_url(species)
+    logging.info("downloading %s -> %s", url, out_path)
+    with urllib.request.urlopen(url, timeout=600) as resp, open(out_path, "wb") as f:
+        while True:
+            chunk = resp.read(1 << 16)
+            if not chunk:
+                break
+            f.write(chunk)
+    return out_path
+
+
+def iter_canonical_protein_coding_transcripts(gtf_path: Path):
+    """Yield (transcript_id, chromosome) for canonical protein-coding transcripts.
+
+    'Canonical' here means the GTF line carries `tag "Ensembl_canonical"`.
+    Ensembl designates exactly one canonical transcript per gene (since
+    release ~107); this matches what `hpc/select_transcripts.py`'s
+    BioMart query used to request.
+    """
+    with gzip.open(gtf_path, "rt") as f:
+        for line in f:
+            if line.startswith("#"):
+                continue
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 9:
+                continue
+            feature_type = fields[2]
+            if feature_type != "transcript":
+                continue
+            attrs = fields[8]
+            # Cheap early-out on biotype (most rows aren't protein_coding).
+            m_biotype = _ATTR_BIOTYPE.search(attrs)
+            if not m_biotype or m_biotype.group(1) != "protein_coding":
+                continue
+            if not _ATTR_TAG_CANONICAL.search(attrs):
+                continue
+            m_tid = _ATTR_TRANSCRIPT_ID.search(attrs)
+            if not m_tid:
+                continue
+            yield m_tid.group(1), fields[0]  # (transcript_id, chromosome)
+
+
+def select_transcripts(
+    candidates: list[tuple[str, str]],
+    n: int,
+    max_chromosomes: int | None,
+    seed: int,
+) -> list[str]:
+    """Sample `n` transcripts spread across up to `max_chromosomes` chromosomes.
+
+    Strategy:
+      * Group candidates by chromosome.
+      * Pick up to `max_chromosomes` chromosomes randomly (from those with
+        the most candidates, to avoid running out on tiny contigs).
+      * Round-robin draw from those buckets until we have n, or fewer if
+        the species genuinely has fewer canonical protein-coding transcripts.
+
+    Output is the resulting transcript_ids as a plain list (order shuffled
+    by the RNG; downstream pre-sort in cli.py re-clusters by chromosome).
+    """
+    rng = random.Random(seed)
+    by_chr: dict[str, list[str]] = defaultdict(list)
+    for tid, chrom in candidates:
+        by_chr[chrom].append(tid)
+
+    # Pick chromosomes. Prefer ones with more candidates so a 10-chromosome
+    # spread on a small genome doesn't fail from a single-transcript contig.
+    ranked_chroms = sorted(by_chr.keys(), key=lambda c: -len(by_chr[c]))
+    if max_chromosomes is None or max_chromosomes >= len(ranked_chroms):
+        picked_chroms = ranked_chroms
+    else:
+        # Take the top `max_chromosomes` by size, then shuffle to decorrelate
+        # chromosome choice from genome assembly order.
+        picked_chroms = ranked_chroms[:max_chromosomes]
+
+    rng.shuffle(picked_chroms)
+    for chrom in picked_chroms:
+        rng.shuffle(by_chr[chrom])
+
+    # Round-robin pull to achieve even spread
+    out: list[str] = []
+    idx = [0] * len(picked_chroms)
+    while len(out) < n:
+        progressed = False
+        for i, chrom in enumerate(picked_chroms):
+            if idx[i] < len(by_chr[chrom]):
+                out.append(by_chr[chrom][idx[i]])
+                idx[i] += 1
+                progressed = True
+                if len(out) >= n:
+                    break
+        if not progressed:
+            break
+    return out
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    target = p.add_mutually_exclusive_group(required=True)
+    target.add_argument("--species", help="Single species slug (e.g. acanthochromis_polyacanthus).")
+    target.add_argument("--species-file", type=Path, help="Newline-separated species slugs.")
+    p.add_argument("--n", type=int, default=100, help="Transcripts per species (default: 100).")
+    p.add_argument("--max-chromosomes", type=int, default=10,
+                   help="Cap distinct chromosomes sampled per species (default: 10).")
+    p.add_argument("--cache-dir", type=Path, default=Path("hpc/ensembl_gtfs"),
+                   help="Where to cache downloaded GTFs.")
+    p.add_argument("--out-dir", type=Path, default=Path("hpc/transcript_lists"),
+                   help="Where to write per-species transcript-id files.")
+    p.add_argument("--seed", type=int, default=20260417,
+                   help="RNG seed for reproducible selection.")
+    p.add_argument("--resume", action="store_true",
+                   help="Skip species whose transcript list already exists.")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    if args.species:
+        species_list = [args.species]
+    else:
+        species_list = [s.strip() for s in args.species_file.read_text().splitlines() if s.strip()]
+    logging.info("processing %d species", len(species_list))
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    manifest: list[dict] = []
+
+    for i, species in enumerate(species_list, 1):
+        out_path = args.out_dir / f"{species}.txt"
+        if args.resume and out_path.exists():
+            logging.info("[%d/%d] %s: skipping (already present)", i, len(species_list), species)
+            continue
+        try:
+            gtf_path = download_gtf(species, args.cache_dir)
+            candidates = list(iter_canonical_protein_coding_transcripts(gtf_path))
+            picked = select_transcripts(candidates, args.n, args.max_chromosomes, args.seed)
+            out_path.write_text("\n".join(picked) + "\n")
+            entry = {
+                "species": species,
+                "status": "ok",
+                "total_canonical_protein_coding": len(candidates),
+                "picked": len(picked),
+                "reduced": len(picked) < args.n,
+            }
+            logging.info("[%d/%d] %s: %d total -> %d picked%s",
+                         i, len(species_list), species, len(candidates), len(picked),
+                         " (REDUCED)" if entry["reduced"] else "")
+        except Exception as exc:
+            entry = {"species": species, "status": "error", "error": str(exc)[:240]}
+            logging.warning("[%d/%d] %s: %s", i, len(species_list), species, exc)
+        manifest.append(entry)
+
+    (args.out_dir / "gtf_selection_manifest.json").write_text(json.dumps(manifest, indent=2))
+    failed = sum(1 for e in manifest if e.get("status") != "ok")
+    logging.info("done: %d ok, %d failed", len(manifest) - failed, failed)
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hpc/puhti/README.md
+++ b/hpc/puhti/README.md
@@ -1,0 +1,132 @@
+# CSC Puhti pipeline for the non-human CAS campaign
+
+End-to-end recipe for running the CAS empirical-p-value build on
+`barker@puhti.csc.fi` (CSC Puhti). Pilot scope: one species,
+100 canonical protein-coding transcripts, promoter window
+`-pb 5000 -pa 5000`, `pvalc=1` (unfiltered), parquet output.
+
+Project dir: `/scratch/project_2001307/ensembl_genomes_CAS_scoring_2018`
+(referred to as `$PROJECT` below).
+
+Workflow is **workstation → Puhti → workstation**; the GTF parsing and
+final aggregation happen on the workstation (small data, quick loops),
+the per-transcript compute runs on Puhti.
+
+## One-time setup on Puhti
+
+```bash
+ssh barker@puhti.csc.fi
+cd /scratch/project_2001307/ensembl_genomes_CAS_scoring_2018
+
+# Clone the tool
+git clone https://github.com/thirtysix/TFBS_footprinting3.git
+cd TFBS_footprinting3
+
+# Load a suitable Python (adjust to Puhti's current selection)
+module load python-data/3.10
+
+# Virtualenv with parquet extras
+python -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+pip install -e '.[parquet]'
+
+# Sanity check
+tfbs_footprinter3 --help | head -2
+```
+
+## Per-species workflow
+
+### 1. Select transcripts (on workstation)
+
+```bash
+# In the repo on your workstation:
+python hpc/ensembl_gtf.py \
+    --species acanthochromis_polyacanthus \
+    --n 100 --max-chromosomes 10
+
+# Produces: hpc/transcript_lists/acanthochromis_polyacanthus.txt
+```
+
+### 2. Copy the transcript list to Puhti
+
+```bash
+SPECIES=acanthochromis_polyacanthus
+PROJECT=/scratch/project_2001307/ensembl_genomes_CAS_scoring_2018
+
+rsync hpc/transcript_lists/${SPECIES}.txt \
+    barker@puhti.csc.fi:${PROJECT}/runs/${SPECIES}/transcripts.txt
+```
+
+### 3. Submit the SLURM job on Puhti
+
+```bash
+ssh barker@puhti.csc.fi
+cd /scratch/project_2001307/ensembl_genomes_CAS_scoring_2018
+
+# One-time: create the per-species run dir
+mkdir -p runs/${SPECIES}
+
+# Launch
+sbatch --export=SPECIES=${SPECIES} \
+    TFBS_footprinting3/hpc/puhti/pilot_submit.sh
+```
+
+**Edit `pilot_submit.sh`'s `#SBATCH` header first** for the billing
+project and partition on your account. The defaults in this repo are
+placeholders.
+
+The job:
+
+* creates `$PROJECT/runs/$SPECIES/` as the working directory
+* runs `tfbs_footprinter3` on the 100 transcripts with
+  `-pb 5000 -pa 5000 -p 1 -pc 1 -no -of parquet`
+* experimental data for the species is auto-downloaded on first run
+  from `s3://tfbssexperimentaldata/${SPECIES}.tar.gz` — no manual copy
+  required
+
+### 4. Aggregate results (on workstation)
+
+```bash
+# Pull the parquet shards back
+rsync -a --include='*.parquet' --include='*/' --exclude='*' \
+    barker@puhti.csc.fi:${PROJECT}/runs/${SPECIES}/tfbs_results/ \
+    hpc/cas_scores/${SPECIES}/
+
+# Roll up into the CAS p-value JSON + thresholds TSV
+python hpc/build_cas_pvalues.py --species ${SPECIES}
+```
+
+Produces `hpc/artifacts/${SPECIES}/CAS_pvalues.0.1.tf_ls.json` in the
+exact format consumed by `tfbs_footprinter3.py:755`
+(`species_specific_data` loads it on startup for that species).
+
+## Scaling to all 316 species
+
+Once the pilot for one species validates end-to-end, the same recipe
+drives all 316 — just run step 1 in batch mode (`--species-file
+/path/to/species_list.txt`) and step 3 once per species (or wrap in
+a SLURM job array that iterates over species).
+
+Projected cost (based on local benchmarking, with pvalc=1, 10kb window,
+parquet output, Ensembl prefetch cache):
+
+| | per species | all 316 |
+|---|---|---|
+| CPU-time | ~1 h (100 transcripts × 35 s) | ~316 h |
+| Wall @ 10-way SLURM array per species | ~6 min | hours |
+| Disk (parquet) | ~5 GB | ~1.6 TB |
+| CAS_pvalues JSON uploaded to S3 | ~MB | ~GB total |
+
+## Notes
+
+- The SLURM submit script expects `SPECIES=<slug>` in the env. Without
+  it the job aborts with a clear error.
+- The tool auto-downloads per-species tarballs from S3 on first run.
+  On compute nodes this requires outbound HTTP access, which Puhti's
+  standard partitions allow. If a partition blocks outbound, stage the
+  tarball manually:
+  `aws s3 cp s3://tfbssexperimentaldata/${SPECIES}.tar.gz ${PROJECT}/TFBS_footprinting3/tfbs_footprinter3/data/`.
+- `-p 1 -pc 1` keeps every hit (no filtering). At 100 transcripts × 10kb
+  window this produces ~1M hits per TF per species, the statistical
+  floor for stable empirical p-values to ~p=1e-4.

--- a/hpc/puhti/build_cas_distributions.py
+++ b/hpc/puhti/build_cas_distributions.py
@@ -13,10 +13,10 @@ Writes two artifacts per species:
      tarball at `tfbs_footprinter3/tfbs_footprinter3.py:755`. For each
      TF, a sorted list of (score, empirical-p-value) pairs.
 
-  2. <out_dir>/<species>/<species>.CAS_thresholds.jaspar_2024.tsv.gz
+  2. <out_dir>/<species>/<species>.CAS_thresholds.jaspar_2018.tsv.gz
 
      The human-readable threshold table mirroring the published
-     `homo_sapiens.CAS_thresholds.jaspar_2024.tsv.gz`. For each TF, one
+     `homo_sapiens.CAS_thresholds.jaspar_2018.tsv.gz`. For each TF, one
      row per target p-value in the same grid the reference pipeline used:
      [0.01..1.0 in 0.01 steps] + [1e-3..1e-12 decades] + a 0.1x grid
      between them.
@@ -171,7 +171,7 @@ def build_for_species(
     json_path.write_text(json.dumps(tf_pvalues_json))
     logging.info("wrote %s (%d TFs)", json_path, tfs_kept)
 
-    tsv_path = out_species_dir / f"{species}.CAS_thresholds.jaspar_2024.tsv.gz"
+    tsv_path = out_species_dir / f"{species}.CAS_thresholds.jaspar_2018.tsv.gz"
     with gzip.open(tsv_path, "wt") as f:
         f.write("tf_name\tp_value\tscore\n")
         for tf_name, p, s in tsv_rows:

--- a/hpc/puhti/build_cas_distributions.py
+++ b/hpc/puhti/build_cas_distributions.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Aggregate tfbs_footprinter3's native per-transcript Parquet output into
+the per-species CAS distribution artifacts.
+
+Reads: `<results_dir>/*/TFBSs_found.sortedclusters.parquet`, the layout
+tfbs_footprinter3 produces when driven with `-of parquet`.
+
+Writes two artifacts per species:
+
+  1. <out_dir>/<species>/CAS_pvalues.0.1.tf_ls.json
+
+     The runtime lookup file `species_specific_data()` loads from the S3
+     tarball at `tfbs_footprinter3/tfbs_footprinter3.py:755`. For each
+     TF, a sorted list of (score, empirical-p-value) pairs.
+
+  2. <out_dir>/<species>/<species>.CAS_thresholds.jaspar_2024.tsv.gz
+
+     The human-readable threshold table mirroring the published
+     `homo_sapiens.CAS_thresholds.jaspar_2024.tsv.gz`. For each TF, one
+     row per target p-value in the same grid the reference pipeline used:
+     [0.01..1.0 in 0.01 steps] + [1e-3..1e-12 decades] + a 0.1x grid
+     between them.
+
+Usage:
+    python hpc/puhti/build_cas_distributions.py \\
+        --species acanthochromis_polyacanthus \\
+        --results-dir runs/acanthochromis_polyacanthus/tfbs_results \\
+        --out-dir hpc/artifacts
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# Column names in the tool's native parquet output (see output.py).
+_TF_COL = "binding prot."
+_CAS_COL = "combined affinity score"
+_ROUND_DECIMALS = 2
+
+# The runtime JSON artifact the tool consumes (`CAS_pvalues.0.1.tf_ls.json`)
+# only stores score-pvalue pairs at p <= 0.1. The reference human file
+# encodes this in the filename ("0.1"). Low-significance scores give no
+# useful CAS threshold; truncating here cuts JSON size ~10x.
+_JSON_PVALUE_CUTOFF = 0.1
+
+
+def _target_p_values() -> list[float]:
+    """Reproduce the grid used in the reference
+    results_extraction.005.py for the human CAS run."""
+    coarse = [x / 100 for x in range(1, 101)]  # 0.01..1.00
+    decades = [10 ** (-x) for x in range(3, 13)]  # 1e-3..1e-12
+    fine = [y * (z / 10) for y in decades for z in range(1, 11)]  # 0.1..1.0 x each decade
+    return sorted(set(coarse + decades + fine), reverse=True)
+
+
+def _load_cas_scores_per_tf(results_dir: Path) -> dict[str, np.ndarray]:
+    """Concatenate CAS scores across every per-transcript parquet in
+    `results_dir`, grouped by TF.
+
+    Returns a dict tf_name -> 1-D float64 ndarray of all that TF's CAS
+    scores across every hit across every transcript.
+    """
+    parquet_files = sorted(results_dir.rglob("TFBSs_found.sortedclusters.parquet"))
+    if not parquet_files:
+        raise FileNotFoundError(f"no parquet files under {results_dir}")
+    logging.info("aggregating %d parquet files from %s", len(parquet_files), results_dir)
+
+    # Stream-concat per-file reads of just the two columns we need so peak
+    # memory stays proportional to one parquet file (~200 MB) instead of
+    # the whole 17 GB species total.
+    per_tf_chunks: dict[str, list[np.ndarray]] = {}
+    for i, path in enumerate(parquet_files, 1):
+        df = pd.read_parquet(path, columns=[_TF_COL, _CAS_COL])
+        for tf_name, sub in df.groupby(_TF_COL, sort=False):
+            per_tf_chunks.setdefault(tf_name, []).append(sub[_CAS_COL].to_numpy())
+        if i % 10 == 0 or i == len(parquet_files):
+            logging.info("  %d/%d parquets read", i, len(parquet_files))
+
+    return {tf: np.concatenate(chunks) for tf, chunks in per_tf_chunks.items()}
+
+
+def _empirical_survival_pvalues(scores: np.ndarray) -> list[tuple[float, float]]:
+    """Return sorted-ascending (score, P(CAS>=score)) tuples.
+
+    Uses the rounded-to-2-decimal convention matching
+    tfbs_footprinter3.py:1073. Survival: P(X >= s) = (# observations
+    >= s) / N.
+    """
+    if scores.size == 0:
+        return []
+    rounded = np.round(scores, _ROUND_DECIMALS)
+    # Sorted unique scores + their counts
+    sorted_scores = np.sort(rounded)
+    unique_scores, first_idx = np.unique(sorted_scores, return_index=True)
+    # For each unique score s, # observations >= s = N - first_idx[s]
+    n = sorted_scores.size
+    survival_counts = n - first_idx.astype(np.float64)
+    p_values = survival_counts / n
+    return [(float(s), float(p)) for s, p in zip(unique_scores, p_values, strict=True)]
+
+
+def _scores_at_target_pvalues(
+    score_pvalue_pairs: list[tuple[float, float]], targets: list[float]
+) -> list[tuple[float, float]]:
+    """Interpolate the score at each target p-value.
+
+    score_pvalue_pairs is sorted ascending by score, so p-values are
+    descending. For each target p, pick the smallest score whose
+    empirical p <= target. If target is smaller than any observed p
+    (tail too thin), emit the largest observed score.
+    """
+    if not score_pvalue_pairs:
+        return []
+    scores = np.array([s for s, _ in score_pvalue_pairs])
+    pvalues = np.array([p for _, p in score_pvalue_pairs])
+    # pvalues are descending in score order. For each target t, find the
+    # first (smallest-score) index where p <= t.
+    out = []
+    for t in targets:
+        mask = pvalues <= t
+        if mask.any():
+            i = int(np.argmax(mask))  # first True
+            out.append((t, float(scores[i])))
+        else:
+            # Target tail is tighter than the distribution resolves; report
+            # the extreme tail score so downstream tools see the right-most
+            # available reference.
+            out.append((t, float(scores[-1])))
+    return out
+
+
+def build_for_species(
+    species: str,
+    results_dir: Path,
+    out_dir: Path,
+    min_hits: int,
+) -> dict:
+    out_species_dir = out_dir / species
+    out_species_dir.mkdir(parents=True, exist_ok=True)
+
+    per_tf_scores = _load_cas_scores_per_tf(results_dir)
+
+    tf_pvalues_json: dict[str, list[list[float]]] = {}
+    tsv_rows: list[tuple[str, float, float]] = []
+    tfs_kept = tfs_dropped = 0
+    targets = _target_p_values()
+
+    for tf_name in sorted(per_tf_scores.keys()):
+        scores = per_tf_scores[tf_name]
+        if scores.size < min_hits:
+            tfs_dropped += 1
+            continue
+        pairs = _empirical_survival_pvalues(scores)
+        # Runtime JSON only carries the significant tail (p <= 0.1); anything
+        # less significant is redundant for CAS lookups. calcCombinedAffinityPvalue
+        # returns ">0.1" for scores below the first entry, which is the right
+        # behavior for non-significant hits.
+        json_pairs = [[s, p] for s, p in pairs if p <= _JSON_PVALUE_CUTOFF]
+        tf_pvalues_json[tf_name] = json_pairs
+        for t, s in _scores_at_target_pvalues(pairs, targets):
+            tsv_rows.append((tf_name, t, s))
+        tfs_kept += 1
+
+    json_path = out_species_dir / "CAS_pvalues.0.1.tf_ls.json"
+    json_path.write_text(json.dumps(tf_pvalues_json))
+    logging.info("wrote %s (%d TFs)", json_path, tfs_kept)
+
+    tsv_path = out_species_dir / f"{species}.CAS_thresholds.jaspar_2024.tsv.gz"
+    with gzip.open(tsv_path, "wt") as f:
+        f.write("tf_name\tp_value\tscore\n")
+        for tf_name, p, s in tsv_rows:
+            f.write(f"{tf_name}\t{p}\t{s}\n")
+    logging.info("wrote %s (%d rows)", tsv_path, len(tsv_rows))
+
+    return {
+        "species": species,
+        "status": "ok",
+        "tfs_kept": tfs_kept,
+        "tfs_dropped": tfs_dropped,
+        "min_hits": min_hits,
+        "json": str(json_path),
+        "tsv": str(tsv_path),
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--species", required=True, help="Species slug (e.g. acanthochromis_polyacanthus).")
+    p.add_argument("--results-dir", type=Path, required=True,
+                   help="The tool's tfbs_results/ directory (contains per-transcript subdirs with parquet shards).")
+    p.add_argument("--out-dir", type=Path, default=Path("hpc/artifacts"),
+                   help="Where per-species artifacts are written (default: hpc/artifacts).")
+    p.add_argument("--min-hits", type=int, default=100,
+                   help="Drop TFs with fewer than this many total hits (default: 100).")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    summary = build_for_species(args.species, args.results_dir, args.out_dir, args.min_hits)
+    logging.info("summary: %s", summary)
+    return 0 if summary["status"] == "ok" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hpc/puhti/build_cas_distributions.py
+++ b/hpc/puhti/build_cas_distributions.py
@@ -44,11 +44,15 @@ _TF_COL = "binding prot."
 _CAS_COL = "combined affinity score"
 _ROUND_DECIMALS = 2
 
-# The runtime JSON artifact the tool consumes (`CAS_pvalues.0.1.tf_ls.json`)
-# only stores score-pvalue pairs at p <= 0.1. The reference human file
-# encodes this in the filename ("0.1"). Low-significance scores give no
-# useful CAS threshold; truncating here cuts JSON size ~10x.
-_JSON_PVALUE_CUTOFF = 0.1
+# NOTE on the "0.1" in the output filename: this is a historical artifact.
+# Early tool releases truncated the JSON to p <= 0.1 to save space, then
+# bisected the remaining sorted list for lookup. The tool still loads the
+# same filename (`tfbs_footprinter3/data_loader.py:306`) and still uses
+# bisect_left on the sorted score list, but there's no reason to keep the
+# truncation: emitting the full distribution lets the tool report p-values
+# for non-significant hits too (p between 0.1 and 1.0), which
+# `pwm_results_summaries/*.CAS_pvalue_score.tsv` was designed to provide.
+# We keep the literal filename for backward compatibility with the loader.
 
 
 def _target_p_values() -> list[float]:
@@ -158,12 +162,7 @@ def build_for_species(
             tfs_dropped += 1
             continue
         pairs = _empirical_survival_pvalues(scores)
-        # Runtime JSON only carries the significant tail (p <= 0.1); anything
-        # less significant is redundant for CAS lookups. calcCombinedAffinityPvalue
-        # returns ">0.1" for scores below the first entry, which is the right
-        # behavior for non-significant hits.
-        json_pairs = [[s, p] for s, p in pairs if p <= _JSON_PVALUE_CUTOFF]
-        tf_pvalues_json[tf_name] = json_pairs
+        tf_pvalues_json[tf_name] = [[s, p] for s, p in pairs]
         for t, s in _scores_at_target_pvalues(pairs, targets):
             tsv_rows.append((tf_name, t, s))
         tfs_kept += 1

--- a/hpc/puhti/pilot_submit.sh
+++ b/hpc/puhti/pilot_submit.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# CSC Puhti SLURM pilot submission for the non-human CAS build.
+#
+# Runs tfbs_footprinter3 on 100 canonical protein-coding transcripts of
+# a single species, promoter window -5kb to +5kb, pvalc=1, parquet
+# output. Intended for one pilot species end-to-end before fanning out
+# to the full 316-species campaign.
+#
+# Usage:
+#   sbatch --export=SPECIES=<species_slug> hpc/puhti/pilot_submit.sh
+#
+# EDIT the #SBATCH lines below for your actual account/partition. The
+# defaults below are placeholders that should work on Puhti's `small`
+# partition for CSC project 2001307.
+
+#SBATCH --job-name=tfbs_cas_pilot
+#SBATCH --account=project_2001307
+#SBATCH --partition=small
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=8G
+#SBATCH --time=02:30:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+set -euo pipefail
+
+: "${SPECIES:?SPECIES env var is required (e.g. acanthochromis_polyacanthus)}"
+: "${PROJECT:=/scratch/project_2001307/ensembl_genomes_CAS_scoring_2018}"
+: "${REPO_ROOT:=${PROJECT}/TFBS_footprinting3}"
+: "${RUN_DIR:=${PROJECT}/runs/${SPECIES}}"
+
+echo "[$(date -Iseconds)] species=${SPECIES}"
+echo "[$(date -Iseconds)] run_dir=${RUN_DIR}"
+mkdir -p "${RUN_DIR}"
+cd "${RUN_DIR}"
+
+# Require the transcripts file to have been rsync'd ahead of time.
+if [[ ! -s transcripts.txt ]]; then
+    echo "FATAL: ${RUN_DIR}/transcripts.txt is missing or empty." >&2
+    echo "Run hpc/ensembl_gtf.py on the workstation and rsync the result first." >&2
+    exit 1
+fi
+
+# Python env set up by hpc/puhti/README.md one-time setup
+module load python-data/3.10
+source "${REPO_ROOT}/venv/bin/activate"
+
+echo "[$(date -Iseconds)] tool version:"
+tfbs_footprinter3 --help | head -1
+
+# The heavy lift. -pb/-pa 5000: 10 kb window. -p -pc 1: keep every hit.
+# -no: no figure (we only need the sortedclusters table). -of parquet:
+# compact binary output, ~10x smaller than CSV.
+echo "[$(date -Iseconds)] launching tfbs_footprinter3"
+tfbs_footprinter3 \
+    -t transcripts.txt \
+    -pb 5000 -pa 5000 \
+    -p 1 -pc 1 \
+    -no \
+    -of parquet
+
+echo "[$(date -Iseconds)] done"
+ls tfbs_results/ | head
+echo "[$(date -Iseconds)] parquet file count: $(find tfbs_results -name '*.parquet' | wc -l)"


### PR DESCRIPTION
## Summary                                             

  Adds the end-to-end infrastructure to generate per-species empirical CAS                                                                                                                                                                               
  (Combined Affinity Score) p-value distributions on CSC Puhti, so non-human
  species can report CAS p-values the same way human does today. All changes                                                                                                                                                                             
  are additive under `hpc/` — runtime tool code (`tfbs_footprinter3/`) is                                                                                                                                                                                
  untouched, so master users are unaffected.                                                                                                                                                                                                             
                                                                                                                                                                                                                                                         
  ## What's included                                                                                                                                                                                                                                     
                                                         
  - `hpc/ensembl_gtf.py` — per-species transcript selection. Downloads the                                                                                                                                                                               
    Ensembl-113 GTF, extracts canonical protein-coding transcripts, and
    samples N spread across up to K chromosomes (default 100 × 10 chromosomes).                                                                                                                                                                          
    GTF over BioMart because BioMart's transient MySQL errors don't scale to                                                                                                                                                                             
    316 species.                                                                                                                                                                                                                                         
  - `hpc/puhti/pilot_submit.sh` — SLURM submit script targeting project                                                                                                                                                                                  
    `2001307` on Puhti's `small` partition. Runs                                                                                                                                                                                                         
    `tfbs_footprinter3 -t transcripts.txt -pb 5000 -pa 5000 -p 1 -pc 1 -no -of parquet`                                                                                                                                                                  
    for the supplied `SPECIES` env var.                                                                                                                                                                                                                  
  - `hpc/puhti/build_cas_distributions.py` — post-run aggregator. Reads the                                                                                                                                                                              
    tool's native per-transcript parquet output, builds the runtime JSON                                                                                                                                                                                 
    (`CAS_pvalues.0.1.tf_ls.json`, emits the full score-pvalue distribution                                                                                                                                                                              
    now that we want p-values reported across the full 0–1 range) and a                                                                                                                                                                                  
    human-readable gzipped threshold TSV mirroring the reference human                                                                                                                                                                                   
    artifact format.                                                                                                                                                                                                                                     
  - `hpc/build_human_cas_thresholds.py` — concatenates the existing per-TF                                                                                                                                                                               
    research-archive TSVs into the same gzipped-TSV format so the human                                                                                                                                                                                  
    artifact can be regenerated without re-running the pipeline.                                                                                                                                                                                         
  - `hpc/puhti/README.md` — end-to-end workflow (one-time setup, per-species                                                                                                                                                                             
    loop, cost forecast for 316 species).                                                                                                                                                                                                                
                                                                                                                                                                                                                                                         
  ## Validation                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                         
  - Pilot-validated end-to-end locally on one non-human transcript (10.3M                                                                                                                                                                                
    hits across 575 TFs, 92s wall).
  - `hpc/ensembl_gtf.py` sanity-checked on *acanthochromis_polyacanthus*:                                                                                                                                                                                
    24,016 canonical protein-coding transcripts → 100 picked evenly across                                                                                                                                                                               
    10 chromosomes.                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                         
  ## Test plan                                                                                                                                                                                                                                           
                                                         
  - [ ] Submit `pilot_submit.sh` for one species on Puhti end-to-end.                                                                                                                                                                                    
  - [ ] `rsync` parquet shards back, run `build_cas_distributions.py`, confirm
        the two artifacts produce plausible p-value distributions.                                                                                                                                                                                       
  - [ ] Spot-check: re-run the tool on ~5 transcripts against the new JSON;                                                                                                                                                                              
        the `combined affinity score p-value` column should be non-empty.                                                                                                                                                                                
                                                                                                                                                                                                                                                         
  ## Not in this PR                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                         
  - JASPAR 2026 migration (separate branch, `feat/jaspar-2026`).                                                                                                                                                                                         
  - Actual 316-species campaign run on Puhti.                                                                                                                                                                                                            
  - S3 tarball regeneration + `tfbs_footprinter3 -update` release bump. 
  
  🤖 Generated with [Claude Code](https://claude.com/claude-code)